### PR TITLE
fixed bug that did not allow grpc to validate requests

### DIFF
--- a/server/cmd/portunus-server/main.go
+++ b/server/cmd/portunus-server/main.go
@@ -144,6 +144,7 @@ func main() {
 			opts = append(opts, grpc.Creds(credentials.NewTLS(&tls.Config{
 				Certificates: []tls.Certificate{cert},
 				MinVersion:   tls.VersionTLS12,
+				NextProtos:   []string{"h2"},
 			})))
 		} else {
 			logger.Printf("gRPC: running WITHOUT TLS (not recommended for production)")


### PR DESCRIPTION
The server's gRPC TLS listener isn't advertising HTTP/2 via ALPN which is required when using the ESP32's gRPC client (nghttp2).