### PR TITLE
fixed code bugs in server and access_module

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,8 +5,12 @@
 #   task test              — run all tests
 #   task test:server       — run server tests only
 #   task build:server      — build the server binary
+#   task build:server:arm64 — cross-compile for Raspberry Pi
+#   task deploy:server     — build, copy, and restart on the Pi
 #   task proto:gen         — regenerate protobuf code (Go + Nanopb)
 #   task firmware:build    — build the ESP32 firmware
+#   task ci:all            — full validation suite
+#   task release           — validate + deploy server + build prod firmware
 #   task clean             — remove build artifacts
 #
 # Cross-platform:
@@ -14,8 +18,18 @@
 #   Python (required by ESP-IDF) handles file operations that would
 #   otherwise need shell-specific syntax. Go and idf.py commands are
 #   natively cross-platform.
+#
+# Deployment:
+#   Deploy tasks use SSH to push the server binary to a Raspberry Pi.
+#   Configure the target in a .env file (gitignored) in the repo root:
+#
+#     DEPLOY_HOST=pi@192.168.1.100
+#     DEPLOY_DIR=/opt/portunus
+#     DEPLOY_SERVICE=portunus-server
 
 version: "3"
+
+dotenv: ['.env']
 
 vars:
   # ── Cross-platform Python resolution ────────────────────────────────────
@@ -99,6 +113,15 @@ tasks:
     dir: "{{.SERVER_DIR}}"
     cmds:
       - go build -o bin/portunus-server{{.EXE}} ./cmd/portunus-server
+
+  build:server:arm64:
+    desc: Cross-compile server binary for Raspberry Pi (arm64)
+    dir: "{{.SERVER_DIR}}"
+    env:
+      GOOS: linux
+      GOARCH: arm64
+    cmds:
+      - go build -o bin/portunus-server-linux-arm64 ./cmd/portunus-server
 
   clean:server:
     desc: Clean server build artifacts
@@ -210,6 +233,58 @@ tasks:
     cmds:
       - idf.py fullclean
 
+  # ─── Deploy ────────────────────────────────────────────────────────────────
+  # Requires SSH key-based auth to the Pi. Configure target in .env:
+  #   DEPLOY_HOST=pi@192.168.1.100
+  #   DEPLOY_DIR=/opt/portunus
+  #   DEPLOY_SERVICE=portunus-server
+
+  deploy:server:
+    desc: Build, copy, and restart the server on the Raspberry Pi
+    deps: [build:server:arm64]
+    vars:
+      DEPLOY_HOST: '{{.DEPLOY_HOST | default "pi@192.168.1.100"}}'
+      DEPLOY_DIR: '{{.DEPLOY_DIR | default "/opt/portunus"}}'
+      DEPLOY_SERVICE: '{{.DEPLOY_SERVICE | default "portunus-server"}}'
+    cmds:
+      - echo "Deploying to {{.DEPLOY_HOST}}:{{.DEPLOY_DIR}}"
+      # Back up current binary on the Pi
+      - ssh {{.DEPLOY_HOST}} "sudo cp {{.DEPLOY_DIR}}/bin/portunus-server {{.DEPLOY_DIR}}/bin/portunus-server.prev 2>/dev/null || true"
+      # Copy new binary
+      - scp {{.SERVER_DIR}}/bin/portunus-server-linux-arm64 {{.DEPLOY_HOST}}:/tmp/portunus-server
+      # Move into place and restart
+      - ssh {{.DEPLOY_HOST}} "sudo mv /tmp/portunus-server {{.DEPLOY_DIR}}/bin/portunus-server && sudo chmod 755 {{.DEPLOY_DIR}}/bin/portunus-server && sudo systemctl restart {{.DEPLOY_SERVICE}}"
+      # Verify
+      - ssh {{.DEPLOY_HOST}} "sudo systemctl is-active {{.DEPLOY_SERVICE}}"
+      - echo "Deploy complete"
+
+  deploy:server:status:
+    desc: Check the server status on the Raspberry Pi
+    vars:
+      DEPLOY_HOST: '{{.DEPLOY_HOST | default "pi@192.168.1.100"}}'
+      DEPLOY_SERVICE: '{{.DEPLOY_SERVICE | default "portunus-server"}}'
+    cmds:
+      - ssh {{.DEPLOY_HOST}} "sudo systemctl status {{.DEPLOY_SERVICE}} --no-pager"
+
+  deploy:server:logs:
+    desc: Tail server logs on the Raspberry Pi
+    vars:
+      DEPLOY_HOST: '{{.DEPLOY_HOST | default "pi@192.168.1.100"}}'
+      DEPLOY_SERVICE: '{{.DEPLOY_SERVICE | default "portunus-server"}}'
+    cmds:
+      - ssh {{.DEPLOY_HOST}} "sudo journalctl -u {{.DEPLOY_SERVICE}} -f"
+
+  deploy:server:rollback:
+    desc: Roll back to the previous server binary on the Raspberry Pi
+    vars:
+      DEPLOY_HOST: '{{.DEPLOY_HOST | default "pi@192.168.1.100"}}'
+      DEPLOY_DIR: '{{.DEPLOY_DIR | default "/opt/portunus"}}'
+      DEPLOY_SERVICE: '{{.DEPLOY_SERVICE | default "portunus-server"}}'
+    cmds:
+      - ssh {{.DEPLOY_HOST}} "sudo systemctl stop {{.DEPLOY_SERVICE}} && sudo cp {{.DEPLOY_DIR}}/bin/portunus-server.prev {{.DEPLOY_DIR}}/bin/portunus-server && sudo systemctl start {{.DEPLOY_SERVICE}}"
+      - ssh {{.DEPLOY_HOST}} "sudo systemctl is-active {{.DEPLOY_SERVICE}}"
+      - echo "Rollback complete"
+
   # ─── CI ───────────────────────────────────────────────────────────────────
 
   proto:check:
@@ -223,3 +298,19 @@ tasks:
       - task: vet:server
       - task: fmt:server
       - task: test:server:race
+
+  ci:all:
+    desc: Full CI — server checks + proto drift + firmware compile
+    cmds:
+      - task: ci:server
+      - task: proto:check
+      - task: firmware:build
+
+  release:
+    desc: Full release — validate, deploy server, build prod firmware
+    cmds:
+      - task: ci:all
+      - task: deploy:server
+      - task: firmware:clean
+      - task: firmware:build:prod
+      - echo "Server deployed. Firmware built. Flash with 'task firmware:flash'"

--- a/access_module/core/system_fsm/src/system_fsm.cpp
+++ b/access_module/core/system_fsm/src/system_fsm.cpp
@@ -82,7 +82,7 @@ portunus_err_t SystemFSM::init()
             ESP_LOGI(TAG, "Credential reader: OK");
         } else {
             m_caps.has_reader = false;
-            ESP_LOGW(TAG, "Credential reader init failed (0x%04x) — card polling disabled" PRIx32, err);
+            ESP_LOGW(TAG, "Credential reader init failed (0x%04x) — card polling disabled PRIx32", err);
         }
     } else {
         m_caps.has_reader = false;
@@ -97,7 +97,7 @@ portunus_err_t SystemFSM::init()
             ESP_LOGI(TAG, "Access point: OK");
         } else {
             m_caps.has_access_point = false;
-            ESP_LOGW(TAG, "Access point init failed (0x%04x) — door control disabled" PRIx32, err);
+            ESP_LOGW(TAG, "Access point init failed (0x%04x) — door control disabled PRIx32", err);
         }
     } else {
         m_caps.has_access_point = false;
@@ -112,7 +112,7 @@ portunus_err_t SystemFSM::init()
             ESP_LOGI(TAG, "Feedback: OK");
         } else {
             m_caps.has_feedback = false;
-            ESP_LOGW(TAG, "Feedback init failed (0x%04x) — LED disabled" PRIx32, err);
+            ESP_LOGW(TAG, "Feedback init failed (0x%04x) — LED disabled PRIx32", err);
         }
     } else {
         m_caps.has_feedback = false;
@@ -325,7 +325,7 @@ void SystemFSM::process_event(const portunus_event_t &event)
                 ESP_LOGI(TAG, "Strike energized — hold timer started (%d ms)",
                          UNLOCK_HOLD_MS);
             } else {
-                ESP_LOGE(TAG, "Failed to unlock: 0x%04x" PRIx32, err);
+                ESP_LOGE(TAG, "Failed to unlock: 0x%04x PRIx32", err);
             }
         } else {
             ESP_LOGW(TAG, "Access granted but no access point — cannot unlock");

--- a/access_module/services/grpc_client/src/grpc_client.cpp
+++ b/access_module/services/grpc_client/src/grpc_client.cpp
@@ -35,6 +35,7 @@
 #include <cstring>
 #include <cstdlib>
 #include <arpa/inet.h>  /* htonl / ntohl */
+#include <sys/socket.h> /* setsockopt / SO_RCVTIMEO */
 
 static const char *TAG = "grpc_client";
 
@@ -568,6 +569,25 @@ portunus_err_t grpc_client_connect(grpc_client_handle_t c)
     }
 
     ESP_LOGI(TAG, "TLS connected, setting up HTTP/2 session");
+
+    /* ── Set a short read timeout on the underlying socket ────────────── */
+    /* Without this, esp_tls_conn_read() blocks indefinitely when no data
+     * is available, which prevents nghttp2_session_recv() from returning
+     * control to the pump loop.  A 100ms timeout causes the read to
+     * return ESP_TLS_ERR_SSL_WANT_READ, which cb_recv maps to
+     * NGHTTP2_ERR_WOULDBLOCK, allowing the pump to loop, send pending
+     * frames (e.g. WINDOW_UPDATE), and retry the read. */
+    {
+        int sock_fd = -1;
+        if (esp_tls_get_conn_sockfd(c->tls, &sock_fd) == ESP_OK && sock_fd >= 0) {
+            struct timeval tv = {};
+            tv.tv_sec  = 0;
+            tv.tv_usec = 100000; /* 100 ms */
+            setsockopt(sock_fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+        } else {
+            ESP_LOGW(TAG, "Could not set socket read timeout — pump may block");
+        }
+    }
 
     /* ── nghttp2 session ───────────────────────────────────────────────── */
 

--- a/server/internal/grpcapi/interceptors.go
+++ b/server/internal/grpcapi/interceptors.go
@@ -5,7 +5,6 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
-	"io"
 	"log"
 	"time"
 
@@ -73,7 +72,6 @@ func HMACInterceptor(secret string) grpc.UnaryServerInterceptor {
 
 		// Compute expected HMAC-SHA256.
 		mac := hmac.New(sha256.New, secretBytes)
-		_, _ = io.WriteString(mac, "")
 		mac.Write(body)
 		expectedSig := mac.Sum(nil)
 

--- a/server/internal/portunus/service/access_service.go
+++ b/server/internal/portunus/service/access_service.go
@@ -142,7 +142,12 @@ func (s *AccessService) recordEvent(
 		rec.RequestedAt = t
 	}
 
-	// CardIDHash left nil — wired up in item 3 (card hashing).
+	// Hash the card ID for the audit trail (same algorithm as card registration).
+	cardID := strings.TrimSpace(req.CardID)
+	if cardID != "" {
+		h := sha256.Sum256([]byte(cardID))
+		rec.CardIDHash = h[:]
+	}
 
 	_ = s.eventStore.RecordEvent(ctx, rec)
 }


### PR DESCRIPTION
Fixed some bugs in the code:
* updated nghttp2 to correctly acknowledge when gRPC data is received and close the connection properly
* fixed access_point_gpio.cpp logging. Corrected comments around PRIx32
* fixed no-op line for the HMAC in interceptors.go. Previously, this was adding a whitespace character which may causing comparison issues between the hash the server produces and the hash the access_module produces. Not an issue for SHA-256, but could be an issue with other hashing algortihms.
* added additional task tasks:
      * build:server:arm64  --> Cross-compiles with GOOS=linux GOARCH=arm64 to server/bin/portunus-server-linux-arm64
      * deploy:server  --> Depends on build:server:arm64, backs up the current binary on the Pi, SCPs the new one via /tmp, moves it into place, restarts the service, and verifies it's active
      * deploy:server:status  --> SSH to the Pi and show systemctl status
      * deploy:server:logs  --> SSH to the Pi and journalctl -f (tail logs)
      * deploy:server:rollback  --> Stops the service, copies .prev back to the main binary, restarts
      * ci:all  --> Runs ci:server + proto:check + firmware:buildreleaseRuns ci:all + deploy:server + clean firmware + prod firmware build