### PR TITLE
update db schema and migrations

### DIFF
--- a/server/internal/db/migrations/0005_roles_rbac.sql
+++ b/server/internal/db/migrations/0005_roles_rbac.sql
@@ -1,0 +1,28 @@
+-- PR 2: RBAC tables — roles and role_permissions
+--
+-- Permissions are atomic named constants defined in code (PR 3).
+-- Roles are runtime data: admin-configurable, with is_system protecting
+-- built-in rows from deletion.
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS roles (
+  role_id                 TEXT    PRIMARY KEY,
+  name                    TEXT    NOT NULL UNIQUE,
+  description             TEXT,
+  is_system               INTEGER NOT NULL DEFAULT 0 CHECK (is_system IN (0,1)),
+  default_expiry_days     INTEGER,
+  default_inactivity_days INTEGER,
+  created_at_ms           INTEGER NOT NULL,
+  updated_at_ms           INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS role_permissions (
+  role_id       TEXT    NOT NULL REFERENCES roles(role_id) ON DELETE CASCADE,
+  permission    TEXT    NOT NULL,
+  granted_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (role_id, permission)
+);
+
+CREATE INDEX IF NOT EXISTS idx_role_permissions_role
+  ON role_permissions(role_id);

--- a/server/internal/db/migrations/0006_member_access.sql
+++ b/server/internal/db/migrations/0006_member_access.sql
@@ -1,0 +1,51 @@
+-- PR 2: member_access table
+--
+-- Unified identity model: members and guests share one table, distinguished
+-- by role_id.  Guest-to-member promotion is a role reassignment on the
+-- existing row — the UUID and credential_hash never change.
+--
+-- credential_hash is nullable until physical enrollment.  The UNIQUE
+-- constraint covers all non-NULL values across all statuses.  The partial
+-- index on (credential_hash) WHERE status = 'active' keeps the hot
+-- access-check path fast regardless of expired row accumulation.
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS member_access (
+  uuid                  TEXT    PRIMARY KEY,
+  role_id               TEXT    NOT NULL REFERENCES roles(role_id),
+  credential_hash       BLOB    UNIQUE
+                                CHECK (credential_hash IS NULL OR length(credential_hash) = 32),
+  status                TEXT    NOT NULL DEFAULT 'active'
+                                CHECK (status IN ('active','suspended','expired','archived')),
+  enabled               INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0,1)),
+  expires_at_ms         INTEGER,
+  inactivity_limit_days INTEGER,
+  last_access_at_ms     INTEGER,
+  created_at_ms         INTEGER NOT NULL,
+  created_by_uuid       TEXT,
+  promoted_from_uuid    TEXT,
+  provisioning_status   TEXT    NOT NULL DEFAULT 'active'
+                                CHECK (provisioning_status IN
+                                  ('pending_authorization','active','incomplete')),
+  archived_at_ms        INTEGER,
+  archived_by_uuid      TEXT
+);
+
+-- Fast path for the access-check query: credential → active member.
+CREATE INDEX IF NOT EXISTS idx_member_access_credential_active
+  ON member_access(credential_hash) WHERE status = 'active';
+
+-- Hard-expiry sweep: find active rows whose deadline has passed.
+CREATE INDEX IF NOT EXISTS idx_member_access_expires
+  ON member_access(expires_at_ms)
+  WHERE status = 'active' AND expires_at_ms IS NOT NULL;
+
+-- Inactivity sweep: find active rows with a last-access timestamp.
+CREATE INDEX IF NOT EXISTS idx_member_access_last_access
+  ON member_access(last_access_at_ms) WHERE status = 'active';
+
+-- Pending-authorization queue ordered by arrival time.
+CREATE INDEX IF NOT EXISTS idx_member_access_pending
+  ON member_access(created_at_ms)
+  WHERE provisioning_status = 'pending_authorization';

--- a/server/internal/db/migrations/0007_module_authorizations.sql
+++ b/server/internal/db/migrations/0007_module_authorizations.sql
@@ -1,0 +1,37 @@
+-- PR 2: module_authorizations join table
+--
+-- Default-deny: no row = no access, regardless of member status.
+-- One active authorization per member per module (UNIQUE constraint).
+-- Revocation is a soft-delete: revoked_at_ms is set, the row is kept for audit.
+-- time_restriction is an optional JSON column for per-authorization policy
+-- (e.g. business-hours-only); NULL means unrestricted.
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS module_authorizations (
+  authorization_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  member_uuid      TEXT    NOT NULL REFERENCES member_access(uuid) ON DELETE CASCADE,
+  module_id        TEXT    NOT NULL REFERENCES modules(module_id)  ON DELETE CASCADE,
+  granted_at_ms    INTEGER NOT NULL,
+  granted_by_uuid  TEXT,
+  expires_at_ms    INTEGER,
+  revoked_at_ms    INTEGER,
+  revoked_by_uuid  TEXT,
+  time_restriction TEXT
+);
+
+-- Enforces one active (non-revoked) grant per member per module.
+-- Revoked rows are kept for audit and do not conflict with new grants.
+CREATE UNIQUE INDEX IF NOT EXISTS uidx_module_auth_active_grant
+  ON module_authorizations(member_uuid, module_id)
+  WHERE revoked_at_ms IS NULL;
+
+-- Fast path for the access-check query: module + member, non-revoked only.
+CREATE INDEX IF NOT EXISTS idx_module_auth_active
+  ON module_authorizations(module_id, member_uuid)
+  WHERE revoked_at_ms IS NULL;
+
+-- Authorization expiry sweep.
+CREATE INDEX IF NOT EXISTS idx_module_auth_expires
+  ON module_authorizations(expires_at_ms)
+  WHERE revoked_at_ms IS NULL AND expires_at_ms IS NOT NULL;

--- a/server/internal/db/migrations/0008_seed_default_roles.sql
+++ b/server/internal/db/migrations/0008_seed_default_roles.sql
@@ -1,0 +1,45 @@
+-- PR 2: built-in default roles
+--
+-- is_system = 1 rows cannot be deleted through the admin API.
+-- Permissions are assigned at runtime via role_permissions; this migration
+-- only establishes the role identities.
+--
+-- INSERT OR IGNORE makes this migration idempotent on re-application.
+
+INSERT OR IGNORE INTO roles
+  (role_id, name, description, is_system, created_at_ms, updated_at_ms)
+VALUES
+  ('admin',
+   'Administrator',
+   'Full system access. All permissions granted.',
+   1,
+   CAST(strftime('%s','now') AS INTEGER) * 1000,
+   CAST(strftime('%s','now') AS INTEGER) * 1000),
+
+  ('operator',
+   'Operator',
+   'Day-to-day operations: provision members, grant and revoke module access.',
+   1,
+   CAST(strftime('%s','now') AS INTEGER) * 1000,
+   CAST(strftime('%s','now') AS INTEGER) * 1000),
+
+  ('viewer',
+   'Viewer',
+   'Read-only access to members, modules, and audit log.',
+   1,
+   CAST(strftime('%s','now') AS INTEGER) * 1000,
+   CAST(strftime('%s','now') AS INTEGER) * 1000),
+
+  ('member',
+   'Member',
+   'Standard member. Inherits default expiry policy from role.',
+   0,
+   CAST(strftime('%s','now') AS INTEGER) * 1000,
+   CAST(strftime('%s','now') AS INTEGER) * 1000),
+
+  ('guest',
+   'Guest',
+   'Temporary access with short default expiry.',
+   0,
+   CAST(strftime('%s','now') AS INTEGER) * 1000,
+   CAST(strftime('%s','now') AS INTEGER) * 1000);

--- a/server/internal/portunus/store/member_access_store.go
+++ b/server/internal/portunus/store/member_access_store.go
@@ -1,0 +1,96 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	ErrMemberCredentialConflict = errors.New("credential already assigned to another member")
+)
+
+// MemberStatus enumerates the lifecycle states of a member_access row.
+type MemberStatus string
+
+const (
+	MemberStatusActive    MemberStatus = "active"
+	MemberStatusSuspended MemberStatus = "suspended"
+	MemberStatusExpired   MemberStatus = "expired"
+	MemberStatusArchived  MemberStatus = "archived"
+)
+
+// ProvisioningStatus enumerates the provisioning workflow states.
+type ProvisioningStatus string
+
+const (
+	ProvisioningStatusPendingAuthorization ProvisioningStatus = "pending_authorization"
+	ProvisioningStatusActive               ProvisioningStatus = "active"
+	ProvisioningStatusIncomplete           ProvisioningStatus = "incomplete"
+)
+
+// MemberAccessRecord represents a row in the member_access table.
+type MemberAccessRecord struct {
+	UUID                string
+	RoleID              string
+	CredentialHash      []byte // nil until enrolled
+	Status              MemberStatus
+	Enabled             bool
+	ExpiresAt           *time.Time
+	InactivityLimitDays *int
+	LastAccessAt        *time.Time
+	CreatedAt           time.Time
+	CreatedByUUID       string
+	PromotedFromUUID    string
+	ProvisioningStatus  ProvisioningStatus
+	ArchivedAt          *time.Time
+	ArchivedByUUID      string
+}
+
+// MemberAccessStore manages the member_access lifecycle.
+type MemberAccessStore interface {
+	// CreateMember inserts a new member_access row with the given identity and
+	// policy. uuid must be a v4 UUID string. createdByUUID may be empty for
+	// bootstrap scenarios.
+	CreateMember(ctx context.Context, uuid, roleID, createdByUUID string,
+		provisioningStatus ProvisioningStatus,
+		expiresAt *time.Time, inactivityLimitDays *int) error
+
+	// GetMember returns the member with the given UUID, or ErrNotFound.
+	GetMember(ctx context.Context, uuid string) (*MemberAccessRecord, error)
+
+	// GetMemberByCredential returns the member whose credential_hash matches,
+	// or ErrNotFound.
+	GetMemberByCredential(ctx context.Context, credentialHash []byte) (*MemberAccessRecord, error)
+
+	// ListMembers returns all member_access rows ordered by created_at_ms DESC.
+	ListMembers(ctx context.Context) ([]MemberAccessRecord, error)
+
+	// ListPendingAuthorizations returns rows with provisioning_status =
+	// 'pending_authorization', ordered by created_at_ms ASC (FIFO queue).
+	ListPendingAuthorizations(ctx context.Context) ([]MemberAccessRecord, error)
+
+	// SetStatus updates the lifecycle status of a member.
+	SetStatus(ctx context.Context, uuid string, status MemberStatus) error
+
+	// SetEnabled updates the enabled flag.
+	SetEnabled(ctx context.Context, uuid string, enabled bool) error
+
+	// AttachCredential sets credential_hash on a member that does not yet have
+	// one. Returns ErrMemberCredentialConflict if the hash is already assigned
+	// to any other member. Returns ErrNotFound if uuid does not exist.
+	AttachCredential(ctx context.Context, uuid string, credentialHash []byte) error
+
+	// SetProvisioningStatus updates provisioning_status.
+	SetProvisioningStatus(ctx context.Context, uuid string, status ProvisioningStatus) error
+
+	// AssignRole changes the role for an existing member.
+	AssignRole(ctx context.Context, uuid, roleID string) error
+
+	// UpdateLastAccess records the time of a granted access event.
+	UpdateLastAccess(ctx context.Context, uuid string, t time.Time) error
+
+	// ArchiveMember transitions a member to archived status and records who
+	// performed the action and when.
+	ArchiveMember(ctx context.Context, uuid, archivedByUUID string) error
+}

--- a/server/internal/portunus/store/module_authorization_store.go
+++ b/server/internal/portunus/store/module_authorization_store.go
@@ -1,0 +1,50 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var ErrAuthorizationAlreadyExists = errors.New("authorization already exists for this member and module")
+
+// ModuleAuthorizationRecord represents a row in the module_authorizations table.
+type ModuleAuthorizationRecord struct {
+	AuthorizationID int64
+	MemberUUID      string
+	ModuleID        string
+	GrantedAt       time.Time
+	GrantedByUUID   string
+	ExpiresAt       *time.Time
+	RevokedAt       *time.Time
+	RevokedByUUID   string
+	TimeRestriction string // JSON; empty string means no restriction
+}
+
+// ModuleAuthorizationStore manages per-module access grants.
+// Default-deny: no row means no access regardless of member status.
+type ModuleAuthorizationStore interface {
+	// GrantAuthorization creates a new authorization. Returns
+	// ErrAuthorizationAlreadyExists if an active (non-revoked) authorization
+	// already exists for the (memberUUID, moduleID) pair.
+	// grantedByUUID may be empty for automated grants.
+	// timeRestriction is an optional JSON policy string; pass "" for none.
+	GrantAuthorization(ctx context.Context, memberUUID, moduleID, grantedByUUID string,
+		expiresAt *time.Time, timeRestriction string) error
+
+	// RevokeAuthorization soft-deletes the authorization by setting
+	// revoked_at_ms. Returns ErrNotFound if no active authorization exists.
+	RevokeAuthorization(ctx context.Context, memberUUID, moduleID, revokedByUUID string) error
+
+	// GetAuthorization returns the most recent authorization for the
+	// (memberUUID, moduleID) pair, or ErrNotFound.
+	GetAuthorization(ctx context.Context, memberUUID, moduleID string) (*ModuleAuthorizationRecord, error)
+
+	// ListByMember returns all authorizations for a member, ordered by
+	// granted_at_ms DESC.
+	ListByMember(ctx context.Context, memberUUID string) ([]ModuleAuthorizationRecord, error)
+
+	// ListByModule returns all authorizations for a module, ordered by
+	// granted_at_ms DESC.
+	ListByModule(ctx context.Context, moduleID string) ([]ModuleAuthorizationRecord, error)
+}

--- a/server/internal/portunus/store/role_store.go
+++ b/server/internal/portunus/store/role_store.go
@@ -1,0 +1,45 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var ErrRoleIsSystem = errors.New("cannot modify or delete a system role")
+
+// RoleRecord represents a row in the roles table.
+type RoleRecord struct {
+	RoleID                string
+	Name                  string
+	Description           string
+	IsSystem              bool
+	DefaultExpiryDays     *int
+	DefaultInactivityDays *int
+	CreatedAt             time.Time
+}
+
+// RoleStore manages runtime-configurable roles and their permission sets.
+type RoleStore interface {
+	// CreateRole inserts a new non-system role.
+	CreateRole(ctx context.Context, roleID, name, description string, defaultExpiryDays, defaultInactivityDays *int) error
+
+	// GetRole returns the role with the given ID, or ErrNotFound.
+	GetRole(ctx context.Context, roleID string) (*RoleRecord, error)
+
+	// ListRoles returns all roles ordered by name.
+	ListRoles(ctx context.Context) ([]RoleRecord, error)
+
+	// DeleteRole removes a role. Returns ErrRoleIsSystem if is_system = 1,
+	// ErrNotFound if the role does not exist.
+	DeleteRole(ctx context.Context, roleID string) error
+
+	// SetRolePermissions replaces the full permission set for a role in a
+	// single transaction. Passing an empty slice clears all permissions.
+	SetRolePermissions(ctx context.Context, roleID string, permissions []string) error
+
+	// GetRolePermissions returns all permission strings assigned to a role,
+	// sorted lexicographically. Returns an empty slice for roles with no
+	// permissions.
+	GetRolePermissions(ctx context.Context, roleID string) ([]string, error)
+}

--- a/server/internal/portunus/store/sqlite/member_access_store.go
+++ b/server/internal/portunus/store/sqlite/member_access_store.go
@@ -1,0 +1,269 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	dbpkg "github.com/BrandonDHaskell/Portunus/server/internal/db"
+	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/store"
+)
+
+type MemberAccessStore struct {
+	db     *sql.DB
+	writer *dbpkg.Worker
+}
+
+func NewMemberAccessStore(db *sql.DB, writer *dbpkg.Worker) *MemberAccessStore {
+	return &MemberAccessStore{db: db, writer: writer}
+}
+
+func (s *MemberAccessStore) CreateMember(ctx context.Context,
+	uuid, roleID, createdByUUID string,
+	provisioningStatus store.ProvisioningStatus,
+	expiresAt *time.Time, inactivityLimitDays *int,
+) error {
+	now := time.Now().UTC().UnixMilli()
+	var expiresAtMs *int64
+	if expiresAt != nil {
+		ms := expiresAt.UTC().UnixMilli()
+		expiresAtMs = &ms
+	}
+	return s.writer.Do(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO member_access(
+  uuid, role_id, status, enabled,
+  expires_at_ms, inactivity_limit_days,
+  created_at_ms, created_by_uuid,
+  provisioning_status)
+VALUES (?, ?, 'active', 1, ?, ?, ?, ?, ?);
+`, uuid, roleID, expiresAtMs, inactivityLimitDays, now, createdByUUID, string(provisioningStatus))
+		if err != nil {
+			return fmt.Errorf("CreateMember: %w", err)
+		}
+		return nil
+	})
+}
+
+func (s *MemberAccessStore) GetMember(ctx context.Context, uuid string) (*store.MemberAccessRecord, error) {
+	row := s.db.QueryRowContext(ctx, memberAccessSelectSQL+` WHERE uuid = ?;`, uuid)
+	rec, err := scanMemberAccessRow(row)
+	if err == sql.ErrNoRows {
+		return nil, store.ErrNotFound
+	}
+	return rec, err
+}
+
+func (s *MemberAccessStore) GetMemberByCredential(ctx context.Context, credentialHash []byte) (*store.MemberAccessRecord, error) {
+	row := s.db.QueryRowContext(ctx, memberAccessSelectSQL+` WHERE credential_hash = ?;`, credentialHash)
+	rec, err := scanMemberAccessRow(row)
+	if err == sql.ErrNoRows {
+		return nil, store.ErrNotFound
+	}
+	return rec, err
+}
+
+func (s *MemberAccessStore) ListMembers(ctx context.Context) ([]store.MemberAccessRecord, error) {
+	rows, err := s.db.QueryContext(ctx, memberAccessSelectSQL+` ORDER BY created_at_ms DESC;`)
+	if err != nil {
+		return nil, fmt.Errorf("ListMembers: %w", err)
+	}
+	return scanMemberAccessRows(rows)
+}
+
+func (s *MemberAccessStore) ListPendingAuthorizations(ctx context.Context) ([]store.MemberAccessRecord, error) {
+	rows, err := s.db.QueryContext(ctx,
+		memberAccessSelectSQL+` WHERE provisioning_status = 'pending_authorization' ORDER BY created_at_ms ASC;`)
+	if err != nil {
+		return nil, fmt.Errorf("ListPendingAuthorizations: %w", err)
+	}
+	return scanMemberAccessRows(rows)
+}
+
+func (s *MemberAccessStore) SetStatus(ctx context.Context, uuid string, status store.MemberStatus) error {
+	return s.writer.Do(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx, `UPDATE member_access SET status = ? WHERE uuid = ?;`, string(status), uuid)
+		if err != nil {
+			return fmt.Errorf("SetStatus: %w", err)
+		}
+		return requireOneRow(res, "SetStatus")
+	})
+}
+
+func (s *MemberAccessStore) SetEnabled(ctx context.Context, uuid string, enabled bool) error {
+	v := 0
+	if enabled {
+		v = 1
+	}
+	return s.writer.Do(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx, `UPDATE member_access SET enabled = ? WHERE uuid = ?;`, v, uuid)
+		if err != nil {
+			return fmt.Errorf("SetEnabled: %w", err)
+		}
+		return requireOneRow(res, "SetEnabled")
+	})
+}
+
+func (s *MemberAccessStore) AttachCredential(ctx context.Context, uuid string, credentialHash []byte) error {
+	if len(credentialHash) != 32 {
+		return fmt.Errorf("credential_hash must be 32 bytes, got %d", len(credentialHash))
+	}
+	return s.writer.Do(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		// Pre-check for a meaningful duplicate error before hitting the UNIQUE constraint.
+		var existingUUID string
+		err := tx.QueryRowContext(ctx,
+			`SELECT uuid FROM member_access WHERE credential_hash = ?;`, credentialHash,
+		).Scan(&existingUUID)
+		if err == nil {
+			return store.ErrMemberCredentialConflict
+		}
+		if err != sql.ErrNoRows {
+			return fmt.Errorf("AttachCredential conflict check: %w", err)
+		}
+
+		res, err := tx.ExecContext(ctx,
+			`UPDATE member_access SET credential_hash = ? WHERE uuid = ?;`, credentialHash, uuid)
+		if err != nil {
+			return fmt.Errorf("AttachCredential: %w", err)
+		}
+		return requireOneRow(res, "AttachCredential")
+	})
+}
+
+func (s *MemberAccessStore) SetProvisioningStatus(ctx context.Context, uuid string, status store.ProvisioningStatus) error {
+	return s.writer.Do(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx,
+			`UPDATE member_access SET provisioning_status = ? WHERE uuid = ?;`, string(status), uuid)
+		if err != nil {
+			return fmt.Errorf("SetProvisioningStatus: %w", err)
+		}
+		return requireOneRow(res, "SetProvisioningStatus")
+	})
+}
+
+func (s *MemberAccessStore) AssignRole(ctx context.Context, uuid, roleID string) error {
+	return s.writer.Do(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx,
+			`UPDATE member_access SET role_id = ? WHERE uuid = ?;`, roleID, uuid)
+		if err != nil {
+			return fmt.Errorf("AssignRole: %w", err)
+		}
+		return requireOneRow(res, "AssignRole")
+	})
+}
+
+func (s *MemberAccessStore) UpdateLastAccess(ctx context.Context, uuid string, t time.Time) error {
+	ms := t.UTC().UnixMilli()
+	return s.writer.Do(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx,
+			`UPDATE member_access SET last_access_at_ms = ? WHERE uuid = ?;`, ms, uuid)
+		if err != nil {
+			return fmt.Errorf("UpdateLastAccess: %w", err)
+		}
+		return requireOneRow(res, "UpdateLastAccess")
+	})
+}
+
+func (s *MemberAccessStore) ArchiveMember(ctx context.Context, uuid, archivedByUUID string) error {
+	now := time.Now().UTC().UnixMilli()
+	return s.writer.Do(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx, `
+UPDATE member_access
+   SET status = 'archived', archived_at_ms = ?, archived_by_uuid = ?
+ WHERE uuid = ?;
+`, now, archivedByUUID, uuid)
+		if err != nil {
+			return fmt.Errorf("ArchiveMember: %w", err)
+		}
+		return requireOneRow(res, "ArchiveMember")
+	})
+}
+
+// ── query helpers ─────────────────────────────────────────────────────────────
+
+const memberAccessSelectSQL = `
+SELECT uuid, role_id, credential_hash, status, enabled,
+       expires_at_ms, inactivity_limit_days, last_access_at_ms,
+       created_at_ms, COALESCE(created_by_uuid,''),
+       COALESCE(promoted_from_uuid,''), provisioning_status,
+       archived_at_ms, COALESCE(archived_by_uuid,'')
+FROM member_access`
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanMemberAccessRow(row rowScanner) (*store.MemberAccessRecord, error) {
+	var (
+		uuid, roleID, statusStr, provStatus string
+		credHash                            []byte
+		enabled                             int
+		expiresMs, lastAccessMs             sql.NullInt64
+		inactivityDays                      sql.NullInt64
+		createdMs                           int64
+		createdBy, promotedFrom             string
+		archivedMs                          sql.NullInt64
+		archivedBy                          string
+	)
+	err := row.Scan(
+		&uuid, &roleID, &credHash, &statusStr, &enabled,
+		&expiresMs, &inactivityDays, &lastAccessMs,
+		&createdMs, &createdBy, &promotedFrom, &provStatus,
+		&archivedMs, &archivedBy,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	rec := &store.MemberAccessRecord{
+		UUID:               uuid,
+		RoleID:             roleID,
+		CredentialHash:     credHash,
+		Status:             store.MemberStatus(statusStr),
+		Enabled:            enabled == 1,
+		CreatedAt:          time.UnixMilli(createdMs).UTC(),
+		CreatedByUUID:      createdBy,
+		PromotedFromUUID:   promotedFrom,
+		ProvisioningStatus: store.ProvisioningStatus(provStatus),
+		ArchivedByUUID:     archivedBy,
+	}
+	if expiresMs.Valid {
+		t := time.UnixMilli(expiresMs.Int64).UTC()
+		rec.ExpiresAt = &t
+	}
+	if inactivityDays.Valid {
+		v := int(inactivityDays.Int64)
+		rec.InactivityLimitDays = &v
+	}
+	if lastAccessMs.Valid {
+		t := time.UnixMilli(lastAccessMs.Int64).UTC()
+		rec.LastAccessAt = &t
+	}
+	if archivedMs.Valid {
+		t := time.UnixMilli(archivedMs.Int64).UTC()
+		rec.ArchivedAt = &t
+	}
+	return rec, nil
+}
+
+func scanMemberAccessRows(rows *sql.Rows) ([]store.MemberAccessRecord, error) {
+	defer rows.Close()
+	var members []store.MemberAccessRecord
+	for rows.Next() {
+		rec, err := scanMemberAccessRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan member_access: %w", err)
+		}
+		members = append(members, *rec)
+	}
+	return members, rows.Err()
+}
+
+func requireOneRow(res sql.Result, op string) error {
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}

--- a/server/internal/portunus/store/sqlite/member_access_store_test.go
+++ b/server/internal/portunus/store/sqlite/member_access_store_test.go
@@ -1,0 +1,439 @@
+package sqlite_test
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/store"
+	sqlitestore "github.com/BrandonDHaskell/Portunus/server/internal/portunus/store/sqlite"
+)
+
+// ── Migration: member_access schema ──────────────────────────────────────────
+
+func TestMigration_MemberAccessTableExists(t *testing.T) {
+	conn := openTestDB(t)
+	ctx := context.Background()
+
+	var name string
+	err := conn.QueryRowContext(ctx,
+		`SELECT name FROM sqlite_master WHERE type='table' AND name='member_access'`,
+	).Scan(&name)
+	if err != nil {
+		t.Fatalf("member_access table not found: %v", err)
+	}
+}
+
+func TestMigration_MemberAccessIndexes(t *testing.T) {
+	conn := openTestDB(t)
+	ctx := context.Background()
+
+	indexes := []string{
+		"idx_member_access_credential_active",
+		"idx_member_access_expires",
+		"idx_member_access_last_access",
+		"idx_member_access_pending",
+	}
+	for _, idx := range indexes {
+		var name string
+		err := conn.QueryRowContext(ctx,
+			`SELECT name FROM sqlite_master WHERE type='index' AND name=?`, idx,
+		).Scan(&name)
+		if err != nil {
+			t.Errorf("expected index %q to exist: %v", idx, err)
+		}
+	}
+}
+
+// ── CreateMember ──────────────────────────────────────────────────────────────
+
+func TestMemberAccessStore_CreateMember_InsertsRow(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	ms := sqlitestore.NewMemberAccessStore(conn, w)
+	ctx := context.Background()
+
+	uuid := "11111111-1111-4111-8111-111111111111"
+	if err := ms.CreateMember(ctx, uuid, "member", "", store.ProvisioningStatusActive, nil, nil); err != nil {
+		t.Fatalf("CreateMember: %v", err)
+	}
+
+	var count int
+	conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM member_access WHERE uuid = ?`, uuid).Scan(&count)
+	if count != 1 {
+		t.Errorf("expected 1 row, got %d", count)
+	}
+}
+
+func TestMemberAccessStore_CreateMember_DefaultsCorrect(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	ms := sqlitestore.NewMemberAccessStore(conn, w)
+	ctx := context.Background()
+
+	uuid := "22222222-2222-4222-8222-222222222222"
+	_ = ms.CreateMember(ctx, uuid, "member", "operator-uuid", store.ProvisioningStatusActive, nil, nil)
+
+	var status string
+	var enabled int
+	var provStatus string
+	conn.QueryRowContext(ctx,
+		`SELECT status, enabled, provisioning_status FROM member_access WHERE uuid = ?`, uuid,
+	).Scan(&status, &enabled, &provStatus)
+
+	if status != "active" {
+		t.Errorf("expected status=active, got %q", status)
+	}
+	if enabled != 1 {
+		t.Errorf("expected enabled=1, got %d", enabled)
+	}
+	if provStatus != "active" {
+		t.Errorf("expected provisioning_status=active, got %q", provStatus)
+	}
+}
+
+func TestMemberAccessStore_CreateMember_PendingAuthorization(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	ms := sqlitestore.NewMemberAccessStore(conn, w)
+	ctx := context.Background()
+
+	uuid := "33333333-3333-4333-8333-333333333333"
+	_ = ms.CreateMember(ctx, uuid, "guest", "", store.ProvisioningStatusPendingAuthorization, nil, nil)
+
+	var provStatus string
+	conn.QueryRowContext(ctx, `SELECT provisioning_status FROM member_access WHERE uuid = ?`, uuid).Scan(&provStatus)
+	if provStatus != "pending_authorization" {
+		t.Errorf("expected pending_authorization, got %q", provStatus)
+	}
+}
+
+func TestMemberAccessStore_CreateMember_WithExpiry(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	ms := sqlitestore.NewMemberAccessStore(conn, w)
+	ctx := context.Background()
+
+	uuid := "44444444-4444-4444-8444-444444444444"
+	exp := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+	_ = ms.CreateMember(ctx, uuid, "guest", "", store.ProvisioningStatusActive, &exp, nil)
+
+	var expiresMs sql.NullInt64
+	conn.QueryRowContext(ctx, `SELECT expires_at_ms FROM member_access WHERE uuid = ?`, uuid).Scan(&expiresMs)
+	if !expiresMs.Valid || expiresMs.Int64 != exp.UnixMilli() {
+		t.Errorf("unexpected expires_at_ms: %v", expiresMs)
+	}
+}
+
+// ── GetMember / GetMemberByCredential ─────────────────────────────────────────
+
+func TestMemberAccessStore_GetMember_NotFound(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	ms := sqlitestore.NewMemberAccessStore(conn, w)
+
+	_, err := ms.GetMember(context.Background(), "nonexistent-uuid")
+	if err != store.ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestMemberAccessStore_GetMember_RoundTrip(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	ms := sqlitestore.NewMemberAccessStore(conn, w)
+	ctx := context.Background()
+
+	uuid := "55555555-5555-4555-8555-555555555555"
+	_ = ms.CreateMember(ctx, uuid, "member", "op-uuid", store.ProvisioningStatusActive, nil, nil)
+
+	rec, err := ms.GetMember(ctx, uuid)
+	if err != nil {
+		t.Fatalf("GetMember: %v", err)
+	}
+	if rec.UUID != uuid {
+		t.Errorf("UUID mismatch: %q", rec.UUID)
+	}
+	if rec.RoleID != "member" {
+		t.Errorf("RoleID mismatch: %q", rec.RoleID)
+	}
+	if rec.CreatedByUUID != "op-uuid" {
+		t.Errorf("CreatedByUUID mismatch: %q", rec.CreatedByUUID)
+	}
+}
+
+func TestMemberAccessStore_GetMemberByCredential_Found(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	ms := sqlitestore.NewMemberAccessStore(conn, w)
+	ctx := context.Background()
+
+	uuid := "66666666-6666-4666-8666-666666666666"
+	hash := randomHash(t)
+	_ = ms.CreateMember(ctx, uuid, "member", "", store.ProvisioningStatusActive, nil, nil)
+	_ = ms.AttachCredential(ctx, uuid, hash)
+
+	rec, err := ms.GetMemberByCredential(ctx, hash)
+	if err != nil {
+		t.Fatalf("GetMemberByCredential: %v", err)
+	}
+	if rec.UUID != uuid {
+		t.Errorf("unexpected UUID: %q", rec.UUID)
+	}
+}
+
+// ── ListMembers / ListPendingAuthorizations ───────────────────────────────────
+
+func TestMemberAccessStore_ListMembers_ReturnsAll(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	ms := sqlitestore.NewMemberAccessStore(conn, w)
+	ctx := context.Background()
+
+	uuids := []string{
+		"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+		"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+	}
+	for _, id := range uuids {
+		_ = ms.CreateMember(ctx, id, "member", "", store.ProvisioningStatusActive, nil, nil)
+	}
+
+	members, err := ms.ListMembers(ctx)
+	if err != nil {
+		t.Fatalf("ListMembers: %v", err)
+	}
+	if len(members) < 2 {
+		t.Errorf("expected at least 2 members, got %d", len(members))
+	}
+}
+
+func TestMemberAccessStore_ListPendingAuthorizations_FiltersCorrectly(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	ms := sqlitestore.NewMemberAccessStore(conn, w)
+	ctx := context.Background()
+
+	pendingID := "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+	activeID := "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+	_ = ms.CreateMember(ctx, pendingID, "guest", "", store.ProvisioningStatusPendingAuthorization, nil, nil)
+	_ = ms.CreateMember(ctx, activeID, "member", "", store.ProvisioningStatusActive, nil, nil)
+
+	pending, err := ms.ListPendingAuthorizations(ctx)
+	if err != nil {
+		t.Fatalf("ListPendingAuthorizations: %v", err)
+	}
+	for _, m := range pending {
+		if m.ProvisioningStatus != store.ProvisioningStatusPendingAuthorization {
+			t.Errorf("non-pending record in list: %q", m.UUID)
+		}
+	}
+	found := false
+	for _, m := range pending {
+		if m.UUID == pendingID {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected pending member %q in list", pendingID)
+	}
+}
+
+// ── Status / Enabled mutations ────────────────────────────────────────────────
+
+func TestMemberAccessStore_SetStatus(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	ms := sqlitestore.NewMemberAccessStore(conn, w)
+	ctx := context.Background()
+
+	uuid := "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
+	_ = ms.CreateMember(ctx, uuid, "member", "", store.ProvisioningStatusActive, nil, nil)
+	_ = ms.SetStatus(ctx, uuid, store.MemberStatusSuspended)
+
+	rec, _ := ms.GetMember(ctx, uuid)
+	if rec.Status != store.MemberStatusSuspended {
+		t.Errorf("expected suspended, got %q", rec.Status)
+	}
+}
+
+func TestMemberAccessStore_SetStatus_NotFound(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	ms := sqlitestore.NewMemberAccessStore(conn, w)
+
+	err := ms.SetStatus(context.Background(), "ghost-uuid", store.MemberStatusSuspended)
+	if err != store.ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestMemberAccessStore_SetEnabled_False(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	ms := sqlitestore.NewMemberAccessStore(conn, w)
+	ctx := context.Background()
+
+	uuid := "ffffffff-ffff-4fff-8fff-ffffffffffff"
+	_ = ms.CreateMember(ctx, uuid, "member", "", store.ProvisioningStatusActive, nil, nil)
+	_ = ms.SetEnabled(ctx, uuid, false)
+
+	rec, _ := ms.GetMember(ctx, uuid)
+	if rec.Enabled {
+		t.Error("expected enabled=false after SetEnabled(false)")
+	}
+}
+
+// ── AttachCredential ──────────────────────────────────────────────────────────
+
+func TestMemberAccessStore_AttachCredential_Success(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	ms := sqlitestore.NewMemberAccessStore(conn, w)
+	ctx := context.Background()
+
+	uuid := "11111111-aaaa-4aaa-8aaa-111111111111"
+	hash := randomHash(t)
+	_ = ms.CreateMember(ctx, uuid, "member", "", store.ProvisioningStatusActive, nil, nil)
+
+	if err := ms.AttachCredential(ctx, uuid, hash); err != nil {
+		t.Fatalf("AttachCredential: %v", err)
+	}
+
+	rec, _ := ms.GetMember(ctx, uuid)
+	if string(rec.CredentialHash) != string(hash) {
+		t.Error("credential_hash not stored correctly")
+	}
+}
+
+func TestMemberAccessStore_AttachCredential_DuplicateConflict(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	ms := sqlitestore.NewMemberAccessStore(conn, w)
+	ctx := context.Background()
+
+	uuid1 := "22222222-aaaa-4aaa-8aaa-222222222222"
+	uuid2 := "33333333-aaaa-4aaa-8aaa-333333333333"
+	hash := randomHash(t)
+
+	_ = ms.CreateMember(ctx, uuid1, "member", "", store.ProvisioningStatusActive, nil, nil)
+	_ = ms.CreateMember(ctx, uuid2, "member", "", store.ProvisioningStatusActive, nil, nil)
+	_ = ms.AttachCredential(ctx, uuid1, hash)
+
+	err := ms.AttachCredential(ctx, uuid2, hash)
+	if err != store.ErrMemberCredentialConflict {
+		t.Errorf("expected ErrMemberCredentialConflict, got %v", err)
+	}
+}
+
+func TestMemberAccessStore_AttachCredential_InvalidHashLength(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	ms := sqlitestore.NewMemberAccessStore(conn, w)
+
+	err := ms.AttachCredential(context.Background(), "any-uuid", []byte{0x01, 0x02})
+	if err == nil {
+		t.Error("expected error for short hash, got nil")
+	}
+}
+
+// ── AssignRole ────────────────────────────────────────────────────────────────
+
+func TestMemberAccessStore_AssignRole(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	ms := sqlitestore.NewMemberAccessStore(conn, w)
+	ctx := context.Background()
+
+	uuid := "44444444-aaaa-4aaa-8aaa-444444444444"
+	_ = ms.CreateMember(ctx, uuid, "guest", "", store.ProvisioningStatusActive, nil, nil)
+	_ = ms.AssignRole(ctx, uuid, "member")
+
+	rec, _ := ms.GetMember(ctx, uuid)
+	if rec.RoleID != "member" {
+		t.Errorf("expected role=member after AssignRole, got %q", rec.RoleID)
+	}
+}
+
+// ── UpdateLastAccess ──────────────────────────────────────────────────────────
+
+func TestMemberAccessStore_UpdateLastAccess(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	ms := sqlitestore.NewMemberAccessStore(conn, w)
+	ctx := context.Background()
+
+	uuid := "55555555-aaaa-4aaa-8aaa-555555555555"
+	_ = ms.CreateMember(ctx, uuid, "member", "", store.ProvisioningStatusActive, nil, nil)
+
+	accessTime := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	_ = ms.UpdateLastAccess(ctx, uuid, accessTime)
+
+	rec, _ := ms.GetMember(ctx, uuid)
+	if rec.LastAccessAt == nil {
+		t.Fatal("expected last_access_at to be set")
+	}
+	if !rec.LastAccessAt.Equal(accessTime) {
+		t.Errorf("unexpected last_access_at: %v", rec.LastAccessAt)
+	}
+}
+
+// ── ArchiveMember ─────────────────────────────────────────────────────────────
+
+func TestMemberAccessStore_ArchiveMember(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	ms := sqlitestore.NewMemberAccessStore(conn, w)
+	ctx := context.Background()
+
+	uuid := "66666666-aaaa-4aaa-8aaa-666666666666"
+	_ = ms.CreateMember(ctx, uuid, "member", "", store.ProvisioningStatusActive, nil, nil)
+	_ = ms.ArchiveMember(ctx, uuid, "admin-uuid")
+
+	rec, _ := ms.GetMember(ctx, uuid)
+	if rec.Status != store.MemberStatusArchived {
+		t.Errorf("expected archived status, got %q", rec.Status)
+	}
+	if rec.ArchivedAt == nil {
+		t.Error("expected archived_at_ms to be set")
+	}
+	if rec.ArchivedByUUID != "admin-uuid" {
+		t.Errorf("expected archived_by_uuid=admin-uuid, got %q", rec.ArchivedByUUID)
+	}
+}
+
+// ── credential_hash UNIQUE constraint ────────────────────────────────────────
+
+func TestMigration_CredentialHashUniqueConstraint(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	ms := sqlitestore.NewMemberAccessStore(conn, w)
+	ctx := context.Background()
+
+	hash := randomHash(t)
+	uuid1 := "77777777-aaaa-4aaa-8aaa-777777777777"
+	uuid2 := "88888888-aaaa-4aaa-8aaa-888888888888"
+
+	_ = ms.CreateMember(ctx, uuid1, "member", "", store.ProvisioningStatusActive, nil, nil)
+	_ = ms.CreateMember(ctx, uuid2, "member", "", store.ProvisioningStatusActive, nil, nil)
+	_ = ms.AttachCredential(ctx, uuid1, hash)
+
+	// Direct SQL to bypass the pre-check: the DB constraint must still fire.
+	_, err := conn.ExecContext(ctx,
+		`UPDATE member_access SET credential_hash = ? WHERE uuid = ?`, hash, uuid2)
+	if err == nil {
+		t.Error("expected UNIQUE constraint violation when assigning same hash to second member")
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func randomHash(t *testing.T) []byte {
+	t.Helper()
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatalf("randomHash: %v", err)
+	}
+	return b
+}

--- a/server/internal/portunus/store/sqlite/module_authorization_store.go
+++ b/server/internal/portunus/store/sqlite/module_authorization_store.go
@@ -1,0 +1,171 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	dbpkg "github.com/BrandonDHaskell/Portunus/server/internal/db"
+	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/store"
+)
+
+type ModuleAuthorizationStore struct {
+	db     *sql.DB
+	writer *dbpkg.Worker
+}
+
+func NewModuleAuthorizationStore(db *sql.DB, writer *dbpkg.Worker) *ModuleAuthorizationStore {
+	return &ModuleAuthorizationStore{db: db, writer: writer}
+}
+
+func (s *ModuleAuthorizationStore) GrantAuthorization(ctx context.Context,
+	memberUUID, moduleID, grantedByUUID string,
+	expiresAt *time.Time, timeRestriction string,
+) error {
+	now := time.Now().UTC().UnixMilli()
+	var expiresAtMs *int64
+	if expiresAt != nil {
+		ms := expiresAt.UTC().UnixMilli()
+		expiresAtMs = &ms
+	}
+	var restrictionVal *string
+	if timeRestriction != "" {
+		restrictionVal = &timeRestriction
+	}
+
+	return s.writer.Do(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		// Check for an existing non-revoked authorization.
+		var existing int
+		err := tx.QueryRowContext(ctx, `
+SELECT 1 FROM module_authorizations
+ WHERE member_uuid = ? AND module_id = ? AND revoked_at_ms IS NULL;
+`, memberUUID, moduleID).Scan(&existing)
+		if err == nil {
+			return store.ErrAuthorizationAlreadyExists
+		}
+		if err != sql.ErrNoRows {
+			return fmt.Errorf("GrantAuthorization conflict check: %w", err)
+		}
+
+		_, err = tx.ExecContext(ctx, `
+INSERT INTO module_authorizations(
+  member_uuid, module_id, granted_at_ms, granted_by_uuid,
+  expires_at_ms, time_restriction)
+VALUES (?, ?, ?, ?, ?, ?);
+`, memberUUID, moduleID, now, grantedByUUID, expiresAtMs, restrictionVal)
+		if err != nil {
+			return fmt.Errorf("GrantAuthorization insert: %w", err)
+		}
+		return nil
+	})
+}
+
+func (s *ModuleAuthorizationStore) RevokeAuthorization(ctx context.Context,
+	memberUUID, moduleID, revokedByUUID string,
+) error {
+	now := time.Now().UTC().UnixMilli()
+	return s.writer.Do(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx, `
+UPDATE module_authorizations
+   SET revoked_at_ms = ?, revoked_by_uuid = ?
+ WHERE member_uuid = ? AND module_id = ? AND revoked_at_ms IS NULL;
+`, now, revokedByUUID, memberUUID, moduleID)
+		if err != nil {
+			return fmt.Errorf("RevokeAuthorization: %w", err)
+		}
+		return requireOneRow(res, "RevokeAuthorization")
+	})
+}
+
+func (s *ModuleAuthorizationStore) GetAuthorization(ctx context.Context,
+	memberUUID, moduleID string,
+) (*store.ModuleAuthorizationRecord, error) {
+	row := s.db.QueryRowContext(ctx,
+		moduleAuthSelectSQL+` WHERE member_uuid = ? AND module_id = ? ORDER BY granted_at_ms DESC LIMIT 1;`,
+		memberUUID, moduleID)
+	rec, err := scanModuleAuthRow(row)
+	if err == sql.ErrNoRows {
+		return nil, store.ErrNotFound
+	}
+	return rec, err
+}
+
+func (s *ModuleAuthorizationStore) ListByMember(ctx context.Context, memberUUID string) ([]store.ModuleAuthorizationRecord, error) {
+	rows, err := s.db.QueryContext(ctx,
+		moduleAuthSelectSQL+` WHERE member_uuid = ? ORDER BY granted_at_ms DESC;`, memberUUID)
+	if err != nil {
+		return nil, fmt.Errorf("ListByMember: %w", err)
+	}
+	return scanModuleAuthRows(rows)
+}
+
+func (s *ModuleAuthorizationStore) ListByModule(ctx context.Context, moduleID string) ([]store.ModuleAuthorizationRecord, error) {
+	rows, err := s.db.QueryContext(ctx,
+		moduleAuthSelectSQL+` WHERE module_id = ? ORDER BY granted_at_ms DESC;`, moduleID)
+	if err != nil {
+		return nil, fmt.Errorf("ListByModule: %w", err)
+	}
+	return scanModuleAuthRows(rows)
+}
+
+// ── query helpers ─────────────────────────────────────────────────────────────
+
+const moduleAuthSelectSQL = `
+SELECT authorization_id, member_uuid, module_id,
+       granted_at_ms, COALESCE(granted_by_uuid,''),
+       expires_at_ms, revoked_at_ms, COALESCE(revoked_by_uuid,''),
+       COALESCE(time_restriction,'')
+FROM module_authorizations`
+
+func scanModuleAuthRow(row rowScanner) (*store.ModuleAuthorizationRecord, error) {
+	var (
+		id                                int64
+		memberUUID, moduleID              string
+		grantedMs                         int64
+		grantedBy                         string
+		expiresMs, revokedMs              sql.NullInt64
+		revokedBy, timeRestriction        string
+	)
+	err := row.Scan(
+		&id, &memberUUID, &moduleID,
+		&grantedMs, &grantedBy,
+		&expiresMs, &revokedMs, &revokedBy,
+		&timeRestriction,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	rec := &store.ModuleAuthorizationRecord{
+		AuthorizationID: id,
+		MemberUUID:      memberUUID,
+		ModuleID:        moduleID,
+		GrantedAt:       time.UnixMilli(grantedMs).UTC(),
+		GrantedByUUID:   grantedBy,
+		RevokedByUUID:   revokedBy,
+		TimeRestriction: timeRestriction,
+	}
+	if expiresMs.Valid {
+		t := time.UnixMilli(expiresMs.Int64).UTC()
+		rec.ExpiresAt = &t
+	}
+	if revokedMs.Valid {
+		t := time.UnixMilli(revokedMs.Int64).UTC()
+		rec.RevokedAt = &t
+	}
+	return rec, nil
+}
+
+func scanModuleAuthRows(rows *sql.Rows) ([]store.ModuleAuthorizationRecord, error) {
+	defer rows.Close()
+	var auths []store.ModuleAuthorizationRecord
+	for rows.Next() {
+		rec, err := scanModuleAuthRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan module_authorizations: %w", err)
+		}
+		auths = append(auths, *rec)
+	}
+	return auths, rows.Err()
+}

--- a/server/internal/portunus/store/sqlite/module_authorization_store.go
+++ b/server/internal/portunus/store/sqlite/module_authorization_store.go
@@ -120,12 +120,12 @@ FROM module_authorizations`
 
 func scanModuleAuthRow(row rowScanner) (*store.ModuleAuthorizationRecord, error) {
 	var (
-		id                                int64
-		memberUUID, moduleID              string
-		grantedMs                         int64
-		grantedBy                         string
-		expiresMs, revokedMs              sql.NullInt64
-		revokedBy, timeRestriction        string
+		id                         int64
+		memberUUID, moduleID       string
+		grantedMs                  int64
+		grantedBy                  string
+		expiresMs, revokedMs       sql.NullInt64
+		revokedBy, timeRestriction string
 	)
 	err := row.Scan(
 		&id, &memberUUID, &moduleID,

--- a/server/internal/portunus/store/sqlite/module_authorization_store_test.go
+++ b/server/internal/portunus/store/sqlite/module_authorization_store_test.go
@@ -1,0 +1,299 @@
+package sqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/store"
+	sqlitestore "github.com/BrandonDHaskell/Portunus/server/internal/portunus/store/sqlite"
+)
+
+// ── Migration: module_authorizations schema ───────────────────────────────────
+
+func TestMigration_ModuleAuthorizationsTableExists(t *testing.T) {
+	conn := openTestDB(t)
+	ctx := context.Background()
+
+	var name string
+	err := conn.QueryRowContext(ctx,
+		`SELECT name FROM sqlite_master WHERE type='table' AND name='module_authorizations'`,
+	).Scan(&name)
+	if err != nil {
+		t.Fatalf("module_authorizations table not found: %v", err)
+	}
+}
+
+func TestMigration_ModuleAuthorizationsIndexes(t *testing.T) {
+	conn := openTestDB(t)
+	ctx := context.Background()
+
+	for _, idx := range []string{
+		"uidx_module_auth_active_grant",
+		"idx_module_auth_active",
+		"idx_module_auth_expires",
+	} {
+		var n string
+		err := conn.QueryRowContext(ctx,
+			`SELECT name FROM sqlite_master WHERE type='index' AND name=?`, idx,
+		).Scan(&n)
+		if err != nil {
+			t.Errorf("expected index %q to exist: %v", idx, err)
+		}
+	}
+}
+
+func TestMigration_ModuleAuthUniqueMemberModule(t *testing.T) {
+	conn := openTestDB(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().UnixMilli()
+	seedModule(t, conn, "mod-001")
+	seedMember(t, conn, "ma-uuid-001")
+
+	_, err := conn.ExecContext(ctx, `
+INSERT INTO module_authorizations(member_uuid, module_id, granted_at_ms)
+VALUES ('ma-uuid-001', 'mod-001', ?)`, now)
+	if err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+	_, err = conn.ExecContext(ctx, `
+INSERT INTO module_authorizations(member_uuid, module_id, granted_at_ms)
+VALUES ('ma-uuid-001', 'mod-001', ?)`, now)
+	if err == nil {
+		t.Error("expected UNIQUE constraint violation on duplicate (member_uuid, module_id)")
+	}
+}
+
+// ── GrantAuthorization ────────────────────────────────────────────────────────
+
+func TestModuleAuthStore_Grant_InsertsRow(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	as := sqlitestore.NewModuleAuthorizationStore(conn, w)
+	ctx := context.Background()
+
+	seedModule(t, conn, "mod-002")
+	seedMember(t, conn, "ma-uuid-002")
+
+	if err := as.GrantAuthorization(ctx, "ma-uuid-002", "mod-002", "admin-uuid", nil, ""); err != nil {
+		t.Fatalf("GrantAuthorization: %v", err)
+	}
+
+	var count int
+	conn.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM module_authorizations WHERE member_uuid='ma-uuid-002' AND module_id='mod-002'`,
+	).Scan(&count)
+	if count != 1 {
+		t.Errorf("expected 1 row, got %d", count)
+	}
+}
+
+func TestModuleAuthStore_Grant_DuplicateConflict(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	as := sqlitestore.NewModuleAuthorizationStore(conn, w)
+	ctx := context.Background()
+
+	seedModule(t, conn, "mod-003")
+	seedMember(t, conn, "ma-uuid-003")
+
+	_ = as.GrantAuthorization(ctx, "ma-uuid-003", "mod-003", "", nil, "")
+	err := as.GrantAuthorization(ctx, "ma-uuid-003", "mod-003", "", nil, "")
+	if err != store.ErrAuthorizationAlreadyExists {
+		t.Errorf("expected ErrAuthorizationAlreadyExists, got %v", err)
+	}
+}
+
+func TestModuleAuthStore_Grant_AllowsAfterRevoke(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	as := sqlitestore.NewModuleAuthorizationStore(conn, w)
+	ctx := context.Background()
+
+	seedModule(t, conn, "mod-004")
+	seedMember(t, conn, "ma-uuid-004")
+
+	_ = as.GrantAuthorization(ctx, "ma-uuid-004", "mod-004", "", nil, "")
+	_ = as.RevokeAuthorization(ctx, "ma-uuid-004", "mod-004", "admin")
+	// Re-granting after revoke should succeed (inserts a new row).
+	if err := as.GrantAuthorization(ctx, "ma-uuid-004", "mod-004", "", nil, ""); err != nil {
+		t.Fatalf("re-grant after revoke: %v", err)
+	}
+}
+
+func TestModuleAuthStore_Grant_WithExpiry(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	as := sqlitestore.NewModuleAuthorizationStore(conn, w)
+	ctx := context.Background()
+
+	seedModule(t, conn, "mod-005")
+	seedMember(t, conn, "ma-uuid-005")
+
+	exp := time.Date(2027, 6, 1, 0, 0, 0, 0, time.UTC)
+	_ = as.GrantAuthorization(ctx, "ma-uuid-005", "mod-005", "", &exp, "")
+
+	rec, err := as.GetAuthorization(ctx, "ma-uuid-005", "mod-005")
+	if err != nil {
+		t.Fatalf("GetAuthorization: %v", err)
+	}
+	if rec.ExpiresAt == nil || !rec.ExpiresAt.Equal(exp) {
+		t.Errorf("unexpected ExpiresAt: %v", rec.ExpiresAt)
+	}
+}
+
+func TestModuleAuthStore_Grant_WithTimeRestriction(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	as := sqlitestore.NewModuleAuthorizationStore(conn, w)
+	ctx := context.Background()
+
+	seedModule(t, conn, "mod-006")
+	seedMember(t, conn, "ma-uuid-006")
+
+	policy := `{"days":["mon","tue","wed","thu","fri"],"start":"08:00","end":"18:00"}`
+	_ = as.GrantAuthorization(ctx, "ma-uuid-006", "mod-006", "", nil, policy)
+
+	rec, _ := as.GetAuthorization(ctx, "ma-uuid-006", "mod-006")
+	if rec.TimeRestriction != policy {
+		t.Errorf("unexpected TimeRestriction: %q", rec.TimeRestriction)
+	}
+}
+
+// ── RevokeAuthorization ───────────────────────────────────────────────────────
+
+func TestModuleAuthStore_Revoke_SetsTimestamp(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	as := sqlitestore.NewModuleAuthorizationStore(conn, w)
+	ctx := context.Background()
+
+	seedModule(t, conn, "mod-007")
+	seedMember(t, conn, "ma-uuid-007")
+
+	_ = as.GrantAuthorization(ctx, "ma-uuid-007", "mod-007", "", nil, "")
+	if err := as.RevokeAuthorization(ctx, "ma-uuid-007", "mod-007", "admin-uuid"); err != nil {
+		t.Fatalf("RevokeAuthorization: %v", err)
+	}
+
+	rec, _ := as.GetAuthorization(ctx, "ma-uuid-007", "mod-007")
+	if rec.RevokedAt == nil {
+		t.Error("expected revoked_at_ms to be set")
+	}
+	if rec.RevokedByUUID != "admin-uuid" {
+		t.Errorf("unexpected revoked_by_uuid: %q", rec.RevokedByUUID)
+	}
+}
+
+func TestModuleAuthStore_Revoke_NotFound(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	as := sqlitestore.NewModuleAuthorizationStore(conn, w)
+
+	err := as.RevokeAuthorization(context.Background(), "ghost", "ghost-mod", "")
+	if err != store.ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// ── GetAuthorization ──────────────────────────────────────────────────────────
+
+func TestModuleAuthStore_GetAuthorization_NotFound(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	as := sqlitestore.NewModuleAuthorizationStore(conn, w)
+
+	_, err := as.GetAuthorization(context.Background(), "nobody", "nomod")
+	if err != store.ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// ── ListByMember / ListByModule ───────────────────────────────────────────────
+
+func TestModuleAuthStore_ListByMember(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	as := sqlitestore.NewModuleAuthorizationStore(conn, w)
+	ctx := context.Background()
+
+	seedModule(t, conn, "mod-010")
+	seedModule(t, conn, "mod-011")
+	seedMember(t, conn, "ma-uuid-010")
+
+	_ = as.GrantAuthorization(ctx, "ma-uuid-010", "mod-010", "", nil, "")
+	_ = as.GrantAuthorization(ctx, "ma-uuid-010", "mod-011", "", nil, "")
+
+	list, err := as.ListByMember(ctx, "ma-uuid-010")
+	if err != nil {
+		t.Fatalf("ListByMember: %v", err)
+	}
+	if len(list) != 2 {
+		t.Errorf("expected 2 authorizations, got %d", len(list))
+	}
+}
+
+func TestModuleAuthStore_ListByModule(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	as := sqlitestore.NewModuleAuthorizationStore(conn, w)
+	ctx := context.Background()
+
+	seedModule(t, conn, "mod-020")
+	seedMember(t, conn, "ma-uuid-020")
+	seedMember(t, conn, "ma-uuid-021")
+
+	_ = as.GrantAuthorization(ctx, "ma-uuid-020", "mod-020", "", nil, "")
+	_ = as.GrantAuthorization(ctx, "ma-uuid-021", "mod-020", "", nil, "")
+
+	list, err := as.ListByModule(ctx, "mod-020")
+	if err != nil {
+		t.Fatalf("ListByModule: %v", err)
+	}
+	if len(list) != 2 {
+		t.Errorf("expected 2 authorizations, got %d", len(list))
+	}
+}
+
+// ── cascade delete ────────────────────────────────────────────────────────────
+
+func TestModuleAuthStore_CascadeOnMemberDelete(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	as := sqlitestore.NewModuleAuthorizationStore(conn, w)
+	ctx := context.Background()
+
+	seedModule(t, conn, "mod-030")
+	seedMember(t, conn, "ma-uuid-030")
+	_ = as.GrantAuthorization(ctx, "ma-uuid-030", "mod-030", "", nil, "")
+
+	_, err := conn.ExecContext(ctx, `DELETE FROM member_access WHERE uuid = 'ma-uuid-030'`)
+	if err != nil {
+		t.Fatalf("delete member: %v", err)
+	}
+
+	var count int
+	conn.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM module_authorizations WHERE member_uuid = 'ma-uuid-030'`,
+	).Scan(&count)
+	if count != 0 {
+		t.Errorf("expected cascade delete of authorizations, got %d rows", count)
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// seedMember inserts a bare member_access row to satisfy FK constraints on
+// module_authorizations.
+func seedMember(t *testing.T, conn *sql.DB, uuid string) {
+	t.Helper()
+	nowMs := time.Now().UTC().UnixMilli()
+	_, err := conn.ExecContext(context.Background(), `
+INSERT OR IGNORE INTO member_access(uuid, role_id, status, enabled, provisioning_status, created_at_ms)
+VALUES (?, 'member', 'active', 1, 'active', ?);`, uuid, nowMs)
+	if err != nil {
+		t.Fatalf("seedMember(%s): %v", uuid, err)
+	}
+}

--- a/server/internal/portunus/store/sqlite/role_store.go
+++ b/server/internal/portunus/store/sqlite/role_store.go
@@ -1,0 +1,167 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	dbpkg "github.com/BrandonDHaskell/Portunus/server/internal/db"
+	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/store"
+)
+
+type RoleStore struct {
+	db     *sql.DB
+	writer *dbpkg.Worker
+}
+
+func NewRoleStore(db *sql.DB, writer *dbpkg.Worker) *RoleStore {
+	return &RoleStore{db: db, writer: writer}
+}
+
+func (s *RoleStore) CreateRole(ctx context.Context, roleID, name, description string, defaultExpiryDays, defaultInactivityDays *int) error {
+	now := time.Now().UTC().UnixMilli()
+	return s.writer.Do(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO roles(role_id, name, description, is_system,
+                 default_expiry_days, default_inactivity_days,
+                 created_at_ms, updated_at_ms)
+VALUES (?, ?, ?, 0, ?, ?, ?, ?);
+`, roleID, name, description, defaultExpiryDays, defaultInactivityDays, now, now)
+		if err != nil {
+			return fmt.Errorf("CreateRole: %w", err)
+		}
+		return nil
+	})
+}
+
+func (s *RoleStore) GetRole(ctx context.Context, roleID string) (*store.RoleRecord, error) {
+	var (
+		id, name, desc string
+		isSystem       int
+		expiryDays     sql.NullInt64
+		inactivityDays sql.NullInt64
+		createdMs      int64
+	)
+	err := s.db.QueryRowContext(ctx, `
+SELECT role_id, name, COALESCE(description,''), is_system,
+       default_expiry_days, default_inactivity_days, created_at_ms
+FROM roles WHERE role_id = ?;
+`, roleID).Scan(&id, &name, &desc, &isSystem, &expiryDays, &inactivityDays, &createdMs)
+	if err == sql.ErrNoRows {
+		return nil, store.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("GetRole: %w", err)
+	}
+	return scanRoleRecord(id, name, desc, isSystem, expiryDays, inactivityDays, createdMs), nil
+}
+
+func (s *RoleStore) ListRoles(ctx context.Context) ([]store.RoleRecord, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT role_id, name, COALESCE(description,''), is_system,
+       default_expiry_days, default_inactivity_days, created_at_ms
+FROM roles ORDER BY name;
+`)
+	if err != nil {
+		return nil, fmt.Errorf("ListRoles: %w", err)
+	}
+	defer rows.Close()
+
+	var roles []store.RoleRecord
+	for rows.Next() {
+		var (
+			id, name, desc string
+			isSystem       int
+			expiryDays     sql.NullInt64
+			inactivityDays sql.NullInt64
+			createdMs      int64
+		)
+		if err := rows.Scan(&id, &name, &desc, &isSystem, &expiryDays, &inactivityDays, &createdMs); err != nil {
+			return nil, fmt.Errorf("ListRoles scan: %w", err)
+		}
+		roles = append(roles, *scanRoleRecord(id, name, desc, isSystem, expiryDays, inactivityDays, createdMs))
+	}
+	return roles, rows.Err()
+}
+
+func (s *RoleStore) DeleteRole(ctx context.Context, roleID string) error {
+	return s.writer.Do(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		var isSystem int
+		err := tx.QueryRowContext(ctx, `SELECT is_system FROM roles WHERE role_id = ?;`, roleID).Scan(&isSystem)
+		if err == sql.ErrNoRows {
+			return store.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("DeleteRole check: %w", err)
+		}
+		if isSystem == 1 {
+			return store.ErrRoleIsSystem
+		}
+		res, err := tx.ExecContext(ctx, `DELETE FROM roles WHERE role_id = ?;`, roleID)
+		if err != nil {
+			return fmt.Errorf("DeleteRole: %w", err)
+		}
+		n, _ := res.RowsAffected()
+		if n == 0 {
+			return store.ErrNotFound
+		}
+		return nil
+	})
+}
+
+func (s *RoleStore) SetRolePermissions(ctx context.Context, roleID string, permissions []string) error {
+	now := time.Now().UTC().UnixMilli()
+	return s.writer.Do(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM role_permissions WHERE role_id = ?;`, roleID); err != nil {
+			return fmt.Errorf("SetRolePermissions delete: %w", err)
+		}
+		for _, p := range permissions {
+			if _, err := tx.ExecContext(ctx, `
+INSERT INTO role_permissions(role_id, permission, granted_at_ms) VALUES (?, ?, ?);
+`, roleID, p, now); err != nil {
+				return fmt.Errorf("SetRolePermissions insert %q: %w", p, err)
+			}
+		}
+		return nil
+	})
+}
+
+func (s *RoleStore) GetRolePermissions(ctx context.Context, roleID string) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT permission FROM role_permissions WHERE role_id = ? ORDER BY permission;
+`, roleID)
+	if err != nil {
+		return nil, fmt.Errorf("GetRolePermissions: %w", err)
+	}
+	defer rows.Close()
+
+	var perms []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			return nil, fmt.Errorf("GetRolePermissions scan: %w", err)
+		}
+		perms = append(perms, p)
+	}
+	return perms, rows.Err()
+}
+
+func scanRoleRecord(id, name, desc string, isSystem int, expiryDays, inactivityDays sql.NullInt64, createdMs int64) *store.RoleRecord {
+	rec := &store.RoleRecord{
+		RoleID:      id,
+		Name:        name,
+		Description: desc,
+		IsSystem:    isSystem == 1,
+		CreatedAt:   time.UnixMilli(createdMs).UTC(),
+	}
+	if expiryDays.Valid {
+		v := int(expiryDays.Int64)
+		rec.DefaultExpiryDays = &v
+	}
+	if inactivityDays.Valid {
+		v := int(inactivityDays.Int64)
+		rec.DefaultInactivityDays = &v
+	}
+	return rec
+}

--- a/server/internal/portunus/store/sqlite/role_store_test.go
+++ b/server/internal/portunus/store/sqlite/role_store_test.go
@@ -1,0 +1,274 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/store"
+	sqlitestore "github.com/BrandonDHaskell/Portunus/server/internal/portunus/store/sqlite"
+)
+
+// ── Migration: default roles seeded ──────────────────────────────────────────
+
+func TestMigration_DefaultRolesExist(t *testing.T) {
+	conn := openTestDB(t)
+	ctx := context.Background()
+
+	expected := []string{"admin", "operator", "viewer", "member", "guest"}
+	for _, id := range expected {
+		var count int
+		err := conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM roles WHERE role_id = ?`, id).Scan(&count)
+		if err != nil {
+			t.Fatalf("query role %q: %v", id, err)
+		}
+		if count != 1 {
+			t.Errorf("expected role %q to exist after migration, count=%d", id, count)
+		}
+	}
+}
+
+func TestMigration_SystemRolesFlagged(t *testing.T) {
+	conn := openTestDB(t)
+	ctx := context.Background()
+
+	systemRoles := []string{"admin", "operator", "viewer"}
+	for _, id := range systemRoles {
+		var isSystem int
+		err := conn.QueryRowContext(ctx, `SELECT is_system FROM roles WHERE role_id = ?`, id).Scan(&isSystem)
+		if err != nil {
+			t.Fatalf("query is_system for %q: %v", id, err)
+		}
+		if isSystem != 1 {
+			t.Errorf("expected role %q to have is_system=1, got %d", id, isSystem)
+		}
+	}
+}
+
+func TestMigration_NonSystemRoles(t *testing.T) {
+	conn := openTestDB(t)
+	ctx := context.Background()
+
+	for _, id := range []string{"member", "guest"} {
+		var isSystem int
+		err := conn.QueryRowContext(ctx, `SELECT is_system FROM roles WHERE role_id = ?`, id).Scan(&isSystem)
+		if err != nil {
+			t.Fatalf("query is_system for %q: %v", id, err)
+		}
+		if isSystem != 0 {
+			t.Errorf("expected role %q to have is_system=0, got %d", id, isSystem)
+		}
+	}
+}
+
+// ── CreateRole ────────────────────────────────────────────────────────────────
+
+func TestRoleStore_CreateRole_InsertsRow(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	rs := sqlitestore.NewRoleStore(conn, w)
+	ctx := context.Background()
+
+	if err := rs.CreateRole(ctx, "custom", "Custom Role", "A test role", nil, nil); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	var count int
+	if err := conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM roles WHERE role_id = 'custom'`).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 row, got %d", count)
+	}
+}
+
+func TestRoleStore_CreateRole_SetsIsSystemFalse(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	rs := sqlitestore.NewRoleStore(conn, w)
+	ctx := context.Background()
+
+	_ = rs.CreateRole(ctx, "custom2", "Another Role", "", nil, nil)
+
+	var isSystem int
+	conn.QueryRowContext(ctx, `SELECT is_system FROM roles WHERE role_id = 'custom2'`).Scan(&isSystem)
+	if isSystem != 0 {
+		t.Errorf("expected is_system=0 for user-created role, got %d", isSystem)
+	}
+}
+
+func TestRoleStore_CreateRole_WithDefaultPolicies(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	rs := sqlitestore.NewRoleStore(conn, w)
+	ctx := context.Background()
+
+	expiry := 30
+	inactivity := 90
+	_ = rs.CreateRole(ctx, "policy_role", "Policy Role", "", &expiry, &inactivity)
+
+	rec, err := rs.GetRole(ctx, "policy_role")
+	if err != nil {
+		t.Fatalf("GetRole: %v", err)
+	}
+	if rec.DefaultExpiryDays == nil || *rec.DefaultExpiryDays != 30 {
+		t.Errorf("unexpected DefaultExpiryDays: %v", rec.DefaultExpiryDays)
+	}
+	if rec.DefaultInactivityDays == nil || *rec.DefaultInactivityDays != 90 {
+		t.Errorf("unexpected DefaultInactivityDays: %v", rec.DefaultInactivityDays)
+	}
+}
+
+// ── GetRole ───────────────────────────────────────────────────────────────────
+
+func TestRoleStore_GetRole_NotFound(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	rs := sqlitestore.NewRoleStore(conn, w)
+
+	_, err := rs.GetRole(context.Background(), "nonexistent")
+	if err != store.ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestRoleStore_GetRole_SystemRole(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	rs := sqlitestore.NewRoleStore(conn, w)
+
+	rec, err := rs.GetRole(context.Background(), "admin")
+	if err != nil {
+		t.Fatalf("GetRole(admin): %v", err)
+	}
+	if !rec.IsSystem {
+		t.Error("expected admin role to be marked is_system")
+	}
+}
+
+// ── ListRoles ─────────────────────────────────────────────────────────────────
+
+func TestRoleStore_ListRoles_IncludesSeeded(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	rs := sqlitestore.NewRoleStore(conn, w)
+
+	roles, err := rs.ListRoles(context.Background())
+	if err != nil {
+		t.Fatalf("ListRoles: %v", err)
+	}
+	if len(roles) < 5 {
+		t.Errorf("expected at least 5 roles (seeded), got %d", len(roles))
+	}
+}
+
+// ── DeleteRole ────────────────────────────────────────────────────────────────
+
+func TestRoleStore_DeleteRole_SystemRoleBlocked(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	rs := sqlitestore.NewRoleStore(conn, w)
+
+	err := rs.DeleteRole(context.Background(), "admin")
+	if err != store.ErrRoleIsSystem {
+		t.Errorf("expected ErrRoleIsSystem deleting admin, got %v", err)
+	}
+}
+
+func TestRoleStore_DeleteRole_NonSystemDeleted(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	rs := sqlitestore.NewRoleStore(conn, w)
+	ctx := context.Background()
+
+	_ = rs.CreateRole(ctx, "temp_role", "Temp", "", nil, nil)
+	if err := rs.DeleteRole(ctx, "temp_role"); err != nil {
+		t.Fatalf("DeleteRole: %v", err)
+	}
+	if _, err := rs.GetRole(ctx, "temp_role"); err != store.ErrNotFound {
+		t.Errorf("expected role to be gone, GetRole returned %v", err)
+	}
+}
+
+func TestRoleStore_DeleteRole_NotFound(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	rs := sqlitestore.NewRoleStore(conn, w)
+
+	err := rs.DeleteRole(context.Background(), "ghost")
+	if err != store.ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// ── SetRolePermissions / GetRolePermissions ───────────────────────────────────
+
+func TestRoleStore_Permissions_RoundTrip(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	rs := sqlitestore.NewRoleStore(conn, w)
+	ctx := context.Background()
+
+	perms := []string{"door.unlock_remote", "member.view"}
+	if err := rs.SetRolePermissions(ctx, "admin", perms); err != nil {
+		t.Fatalf("SetRolePermissions: %v", err)
+	}
+
+	got, err := rs.GetRolePermissions(ctx, "admin")
+	if err != nil {
+		t.Fatalf("GetRolePermissions: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 permissions, got %d: %v", len(got), got)
+	}
+	// Results are sorted lexicographically.
+	if got[0] != "door.unlock_remote" || got[1] != "member.view" {
+		t.Errorf("unexpected permissions: %v", got)
+	}
+}
+
+func TestRoleStore_Permissions_ReplaceIsFull(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	rs := sqlitestore.NewRoleStore(conn, w)
+	ctx := context.Background()
+
+	_ = rs.SetRolePermissions(ctx, "operator", []string{"door.unlock_remote", "member.view"})
+	_ = rs.SetRolePermissions(ctx, "operator", []string{"member.view"})
+
+	got, _ := rs.GetRolePermissions(ctx, "operator")
+	if len(got) != 1 || got[0] != "member.view" {
+		t.Errorf("expected only member.view after replace, got %v", got)
+	}
+}
+
+func TestRoleStore_Permissions_ClearAll(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	rs := sqlitestore.NewRoleStore(conn, w)
+	ctx := context.Background()
+
+	_ = rs.SetRolePermissions(ctx, "viewer", []string{"audit.view"})
+	_ = rs.SetRolePermissions(ctx, "viewer", nil)
+
+	got, _ := rs.GetRolePermissions(ctx, "viewer")
+	if len(got) != 0 {
+		t.Errorf("expected empty permission list, got %v", got)
+	}
+}
+
+func TestRoleStore_Permissions_DeleteCascades(t *testing.T) {
+	conn := openTestDB(t)
+	w := newTestWriter(t, conn)
+	rs := sqlitestore.NewRoleStore(conn, w)
+	ctx := context.Background()
+
+	_ = rs.CreateRole(ctx, "cascade_role", "Cascade", "", nil, nil)
+	_ = rs.SetRolePermissions(ctx, "cascade_role", []string{"door.unlock_remote"})
+	_ = rs.DeleteRole(ctx, "cascade_role")
+
+	var count int
+	conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM role_permissions WHERE role_id = 'cascade_role'`).Scan(&count)
+	if count != 0 {
+		t.Errorf("expected role_permissions to cascade-delete, got %d rows", count)
+	}
+}


### PR DESCRIPTION
Migrations (4 new files):

[0005_roles_rbac.sql](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/server/internal/db/migrations/0005_roles_rbac.sql) — roles + role_permissions tables with cascade delete
[0006_member_access.sql](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/server/internal/db/migrations/0006_member_access.sql) — member_access table with all lifecycle columns, 4 partial indexes (active-credential, expiry sweep, inactivity sweep, pending queue)
[0007_module_authorizations.sql](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/server/internal/db/migrations/0007_module_authorizations.sql) — module_authorizations join table; the UNIQUE guarantee is a partial unique index on (member_uuid, module_id) WHERE revoked_at_ms IS NULL so revoked rows don't block re-grants while still enforcing one active grant per pair
[0008_seed_default_roles.sql](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/server/internal/db/migrations/0008_seed_default_roles.sql) — 5 default roles (admin/operator/viewer are is_system=1; member/guest are not); idempotent via INSERT OR IGNORE
Store interfaces (3 new files):

[role_store.go](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/server/internal/portunus/store/role_store.go) — RoleStore with ErrRoleIsSystem sentinel
[member_access_store.go](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/server/internal/portunus/store/member_access_store.go) — MemberAccessStore with typed MemberStatus / ProvisioningStatus constants
[module_authorization_store.go](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/server/internal/portunus/store/module_authorization_store.go) — ModuleAuthorizationStore with ErrAuthorizationAlreadyExists sentinel