### PR TITLE
add member and authorization management UI and Pending Queue

### DIFF
--- a/server/internal/httpapi/server.go
+++ b/server/internal/httpapi/server.go
@@ -161,6 +161,9 @@ func NewServer(d Dependencies) *Server {
 	if d.RoleService != nil {
 		s.uiRoleRoutes(mux)
 	}
+	if d.MemberAccessService != nil {
+		s.uiMemberRoutes(mux)
+	}
 
 	// Build middleware chain: logging → HSTS (if TLS) → session → HMAC → mux
 	var handler http.Handler = mux

--- a/server/internal/httpapi/templates/base.html
+++ b/server/internal/httpapi/templates/base.html
@@ -12,6 +12,8 @@
   {{if .Session}}
   <a href="/admin/ui/users" {{if eq .ActivePage "users"}}class="active"{{end}}>Users</a>
   <a href="/admin/ui/roles" {{if eq .ActivePage "roles"}}class="active"{{end}}>Roles</a>
+  <a href="/admin/ui/members" {{if eq .ActivePage "members"}}class="active"{{end}}>Members</a>
+  <a href="/admin/ui/members/pending" {{if eq .ActivePage "pending"}}class="active"{{end}}>Pending</a>
   <span class="nav-user">{{.Session.Username}} ({{.Session.RoleID}}) &nbsp;
     <form method="POST" action="/admin/ui/logout" style="display:inline">
       <button class="btn btn-secondary btn-sm" type="submit">Sign out</button>

--- a/server/internal/httpapi/templates/members_detail.html
+++ b/server/internal/httpapi/templates/members_detail.html
@@ -1,0 +1,250 @@
+{{define "title"}}Member — Portunus Admin{{end}}
+{{define "content"}}
+<div class="page-header">
+  <h1>Member Detail</h1>
+  <a class="btn btn-secondary" href="/admin/ui/members">← Members</a>
+</div>
+
+{{with .Member}}
+<!-- ── Identity ──────────────────────────────────────────────────────────── -->
+<div class="card" style="margin-bottom:1.5rem">
+  <h2 style="margin-top:0">Identity</h2>
+  <div class="form-group">
+    <label>UUID</label>
+    <div style="display:flex;align-items:center;gap:.5rem">
+      <input type="text" class="font-mono" value="{{.UUID}}" readonly style="flex:1">
+      <button class="btn btn-secondary btn-sm"
+        onclick="navigator.clipboard.writeText('{{.UUID}}').then(()=>this.textContent='Copied!').catch(()=>{})"
+        title="Copy UUID to clipboard">Copy UUID</button>
+    </div>
+    <p class="hint">Share this UUID with the external membership system to link the physical credential to a person.</p>
+  </div>
+  <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem">
+    <div class="form-group">
+      <label>Role</label>
+      <input type="text" value="{{.RoleID}}" readonly>
+    </div>
+    <div class="form-group">
+      <label>Status</label>
+      <div style="margin-top:.25rem">
+        {{if eq .Status "active"}}
+          {{if .Enabled}}<span class="badge badge-green">Active</span>
+          {{else}}<span class="badge badge-yellow">Disabled</span>{{end}}
+        {{else if eq .Status "expired"}}
+          <span class="badge badge-red">Expired</span>
+        {{else if eq .Status "archived"}}
+          <span class="badge">Archived</span>
+        {{else}}
+          <span class="badge">{{.Status}}</span>
+        {{end}}
+      </div>
+    </div>
+    <div class="form-group">
+      <label>Provisioning Status</label>
+      <div style="margin-top:.25rem">
+        {{if eq .ProvisioningStatus "pending_authorization"}}
+          <span class="badge badge-yellow">Pending Authorization</span>
+        {{else if eq .ProvisioningStatus "active"}}
+          <span class="badge badge-green">Active</span>
+        {{else}}
+          <span class="badge">{{.ProvisioningStatus}}</span>
+        {{end}}
+      </div>
+    </div>
+    <div class="form-group">
+      <label>Credential (hash prefix)</label>
+      <input type="text" class="font-mono" value="{{if .CredentialHash}}{{.CredentialHash}}{{else}}— none attached —{{end}}" readonly>
+    </div>
+    <div class="form-group">
+      <label>Expires</label>
+      <input type="text" value="{{if .ExpiresAt}}{{.ExpiresAt}}{{else}}— no expiry —{{end}}" readonly>
+    </div>
+    <div class="form-group">
+      <label>Inactivity Limit</label>
+      <input type="text" value="{{if .InactivityLimitDays}}{{derefInt .InactivityLimitDays}} days{{else}}— none —{{end}}" readonly>
+    </div>
+    <div class="form-group">
+      <label>Last Access</label>
+      <input type="text" value="{{if .LastAccessAt}}{{.LastAccessAt}}{{else}}Never{{end}}" readonly>
+    </div>
+    <div class="form-group">
+      <label>Created</label>
+      <input type="text" value="{{.CreatedAt}}" readonly>
+    </div>
+  </div>
+  {{if .ArchivedAt}}
+  <p class="hint">Archived {{.ArchivedAt}}{{if .ArchivedByUUID}} by {{.ArchivedByUUID}}{{end}}.</p>
+  {{end}}
+</div>
+
+<!-- ── Actions ───────────────────────────────────────────────────────────── -->
+{{if not (eq .Status "archived")}}
+<div class="card" style="margin-bottom:1.5rem">
+  <h2 style="margin-top:0">Actions</h2>
+  <div style="display:flex;flex-wrap:wrap;gap:.75rem;align-items:flex-start">
+
+    <!-- Attach credential -->
+    {{if not .CredentialHash}}
+    <form method="POST" action="/admin/ui/members/{{.UUID}}/credential" style="display:flex;gap:.5rem;align-items:flex-end">
+      <div class="form-group" style="margin:0">
+        <label for="credential_hash">Attach Credential Hash (64 hex chars)</label>
+        <input id="credential_hash" name="credential_hash" type="text" class="font-mono"
+          placeholder="sha256 hex…" maxlength="64" style="width:28rem">
+      </div>
+      <button class="btn btn-primary" type="submit">Attach</button>
+    </form>
+    {{end}}
+
+    <!-- Assign role -->
+    {{if $.Roles}}
+    <form method="POST" action="/admin/ui/members/{{.UUID}}/role" style="display:flex;gap:.5rem;align-items:flex-end">
+      <div class="form-group" style="margin:0">
+        <label for="role_id">Assign Role</label>
+        <select id="role_id" name="role_id" required>
+          {{range $.Roles}}
+          <option value="{{.RoleID}}" {{if eq .RoleID $.Member.RoleID}}selected{{end}}>{{.Name}}</option>
+          {{end}}
+        </select>
+      </div>
+      <button class="btn btn-secondary" type="submit">Save Role</button>
+    </form>
+    {{end}}
+
+    <!-- Enable / Disable -->
+    {{if .Enabled}}
+    <form method="POST" action="/admin/ui/members/{{.UUID}}/disable">
+      <button class="btn btn-danger" type="submit"
+        onclick="return confirm('Disable this member?')">Disable</button>
+    </form>
+    {{else}}
+    <form method="POST" action="/admin/ui/members/{{.UUID}}/enable">
+      <button class="btn btn-secondary" type="submit">Enable</button>
+    </form>
+    {{end}}
+
+    <!-- Archive -->
+    <form method="POST" action="/admin/ui/members/{{.UUID}}/archive">
+      <button class="btn btn-danger" type="submit"
+        onclick="return confirm('Archive this member? This cannot be easily undone.')">Archive</button>
+    </form>
+  </div>
+</div>
+{{end}}
+{{end}}{{/* end with .Member */}}
+
+<!-- ── Module Authorizations ─────────────────────────────────────────────── -->
+<div class="card" style="margin-bottom:1.5rem">
+  <h2 style="margin-top:0">Module Authorizations</h2>
+
+  {{if .Authorizations}}
+  <table style="margin-bottom:1rem">
+    <thead>
+      <tr>
+        <th>Module</th>
+        <th>Granted</th>
+        <th>Granted By</th>
+        <th>Expires</th>
+        <th>Status</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+    {{range .Authorizations}}
+      <tr>
+        <td class="font-mono">{{.ModuleID}}</td>
+        <td class="text-muted" style="font-size:.85rem">{{.GrantedAt}}</td>
+        <td class="font-mono text-muted" style="font-size:.8rem">
+          {{if .GrantedByUUID}}{{.GrantedByUUID}}{{else}}<em>system</em>{{end}}
+        </td>
+        <td class="text-muted" style="font-size:.85rem">
+          {{if .ExpiresAt}}{{.ExpiresAt}}{{else}}—{{end}}
+        </td>
+        <td>
+          {{if .RevokedAt}}
+            <span class="badge badge-red">Revoked</span>
+          {{else}}
+            <span class="badge badge-green">Active</span>
+          {{end}}
+        </td>
+        <td>
+          {{if not .RevokedAt}}
+          <form method="POST" action="/admin/ui/members/{{$.Member.UUID}}/authorizations/{{.ModuleID}}/revoke">
+            <button class="btn btn-danger btn-sm" type="submit"
+              onclick="return confirm('Revoke access to {{.ModuleID}}?')">Revoke</button>
+          </form>
+          {{end}}
+        </td>
+      </tr>
+    {{end}}
+    </tbody>
+  </table>
+  {{else}}
+  <p class="text-muted">No module authorizations yet.</p>
+  {{end}}
+
+  <!-- Grant authorization form -->
+  {{if and $.Modules $.Member}}
+  {{if not (eq $.Member.Status "archived")}}
+  <details style="margin-top:1rem">
+    <summary class="btn btn-secondary" style="display:inline-block;cursor:pointer">+ Grant Authorization</summary>
+    <form method="POST" action="/admin/ui/members/{{$.Member.UUID}}/authorizations"
+          style="margin-top:1rem;display:flex;gap:.5rem;align-items:flex-end;flex-wrap:wrap">
+      <div class="form-group" style="margin:0">
+        <label for="module_id">Module</label>
+        <select id="module_id" name="module_id" required>
+          <option value="">— Select module —</option>
+          {{range $.Modules}}
+          <option value="{{.ModuleID}}">{{if .DisplayName}}{{.DisplayName}} ({{.ModuleID}}){{else}}{{.ModuleID}}{{end}}</option>
+          {{end}}
+        </select>
+      </div>
+      <div class="form-group" style="margin:0">
+        <label for="auth_expires_at">Expires (optional)</label>
+        <input id="auth_expires_at" name="expires_at" type="date">
+      </div>
+      <button class="btn btn-primary" type="submit">Grant</button>
+    </form>
+  </details>
+  {{end}}
+  {{end}}
+</div>
+
+<!-- ── Access Event History ───────────────────────────────────────────────── -->
+<div class="card">
+  <h2 style="margin-top:0">Recent Access Events</h2>
+  {{if .AccessEvents}}
+  <table>
+    <thead>
+      <tr>
+        <th>Module</th>
+        <th>Time (UTC)</th>
+        <th>Result</th>
+        <th>Reason</th>
+      </tr>
+    </thead>
+    <tbody>
+    {{range .AccessEvents}}
+      <tr>
+        <td class="font-mono">{{.ModuleID}}</td>
+        <td class="text-muted" style="font-size:.85rem">{{.ReceivedAt}}</td>
+        <td>
+          {{if .Granted}}
+            <span class="badge badge-green">Granted</span>
+          {{else}}
+            <span class="badge badge-red">Denied</span>
+          {{end}}
+        </td>
+        <td class="text-muted" style="font-size:.85rem">{{.Reason}}</td>
+      </tr>
+    {{end}}
+    </tbody>
+  </table>
+  {{else if .Member}}
+    {{if .Member.CredentialHash}}
+      <p class="text-muted">No access events recorded yet.</p>
+    {{else}}
+      <p class="text-muted">No credential attached — access events will appear here once a credential is enrolled.</p>
+    {{end}}
+  {{end}}
+</div>
+{{end}}

--- a/server/internal/httpapi/templates/members_list.html
+++ b/server/internal/httpapi/templates/members_list.html
@@ -1,0 +1,61 @@
+{{define "title"}}Members — Portunus Admin{{end}}
+{{define "content"}}
+<div class="page-header">
+  <h1>Members</h1>
+  <div style="display:flex;gap:.5rem">
+    <a class="btn btn-secondary" href="/admin/ui/members/pending">Pending Queue</a>
+    <a class="btn btn-primary" href="/admin/ui/members/new">+ Provision Member</a>
+  </div>
+</div>
+<table>
+  <thead>
+    <tr>
+      <th>UUID</th>
+      <th>Role</th>
+      <th>Status</th>
+      <th>Provisioning</th>
+      <th>Credential</th>
+      <th>Created</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+  {{range .Members}}
+    <tr>
+      <td class="font-mono" style="font-size:.8rem">{{.UUID}}</td>
+      <td><span class="badge badge-blue">{{.RoleID}}</span></td>
+      <td>
+        {{if eq .Status "active"}}
+          {{if .Enabled}}<span class="badge badge-green">Active</span>
+          {{else}}<span class="badge badge-yellow">Disabled</span>{{end}}
+        {{else if eq .Status "expired"}}
+          <span class="badge badge-red">Expired</span>
+        {{else if eq .Status "archived"}}
+          <span class="badge">Archived</span>
+        {{else}}
+          <span class="badge">{{.Status}}</span>
+        {{end}}
+      </td>
+      <td>
+        {{if eq .ProvisioningStatus "pending_authorization"}}
+          <span class="badge badge-yellow">Pending</span>
+        {{else if eq .ProvisioningStatus "active"}}
+          <span class="badge badge-green">Active</span>
+        {{else}}
+          <span class="badge">{{.ProvisioningStatus}}</span>
+        {{end}}
+      </td>
+      <td class="font-mono text-muted" style="font-size:.8rem">
+        {{if .CredentialHash}}{{.CredentialHash}}{{else}}<em>none</em>{{end}}
+      </td>
+      <td class="text-muted" style="font-size:.85rem">{{.CreatedAt}}</td>
+      <td>
+        <a class="btn btn-secondary btn-sm" href="/admin/ui/members/{{.UUID}}">View</a>
+      </td>
+    </tr>
+  {{else}}
+    <tr><td colspan="7" class="text-muted" style="text-align:center;padding:2rem">No members found.</td></tr>
+  {{end}}
+  </tbody>
+</table>
+{{end}}

--- a/server/internal/httpapi/templates/members_pending.html
+++ b/server/internal/httpapi/templates/members_pending.html
@@ -1,0 +1,47 @@
+{{define "title"}}Pending Authorizations — Portunus Admin{{end}}
+{{define "content"}}
+<div class="page-header">
+  <h1>Pending Authorizations</h1>
+  <a class="btn btn-secondary" href="/admin/ui/members">← All Members</a>
+</div>
+<p class="text-muted">Members provisioned via the physical console awaiting module authorization assignment. Ordered oldest-first (FIFO).</p>
+<table>
+  <thead>
+    <tr>
+      <th>UUID</th>
+      <th>Role</th>
+      <th>Credential</th>
+      <th>Created</th>
+      <th>Created By</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+  {{range .Members}}
+    <tr>
+      <td>
+        <div style="display:flex;align-items:center;gap:.5rem">
+          <span class="font-mono" style="font-size:.8rem">{{.UUID}}</span>
+          <button class="btn btn-secondary btn-sm"
+            onclick="navigator.clipboard.writeText('{{.UUID}}').then(()=>this.textContent='Copied!').catch(()=>{})"
+            title="Copy UUID to clipboard">Copy</button>
+        </div>
+      </td>
+      <td><span class="badge badge-blue">{{.RoleID}}</span></td>
+      <td class="font-mono text-muted" style="font-size:.8rem">
+        {{if .CredentialHash}}{{.CredentialHash}}{{else}}<em>not yet attached</em>{{end}}
+      </td>
+      <td class="text-muted" style="font-size:.85rem">{{.CreatedAt}}</td>
+      <td class="font-mono text-muted" style="font-size:.8rem">
+        {{if .CreatedByUUID}}{{.CreatedByUUID}}{{else}}<em>system</em>{{end}}
+      </td>
+      <td>
+        <a class="btn btn-primary btn-sm" href="/admin/ui/members/{{.UUID}}">Authorize →</a>
+      </td>
+    </tr>
+  {{else}}
+    <tr><td colspan="6" class="text-muted" style="text-align:center;padding:2rem">No pending authorizations.</td></tr>
+  {{end}}
+  </tbody>
+</table>
+{{end}}

--- a/server/internal/httpapi/templates/members_provision.html
+++ b/server/internal/httpapi/templates/members_provision.html
@@ -1,0 +1,40 @@
+{{define "title"}}Provision Member — Portunus Admin{{end}}
+{{define "content"}}
+<div class="page-header">
+  <h1>Provision Member</h1>
+  <a class="btn btn-secondary" href="/admin/ui/members">← Members</a>
+</div>
+<div class="card" style="max-width:520px">
+  <p class="hint" style="margin-top:0">
+    This creates a new member record with a server-generated UUID.
+    The UUID must be copied to the external membership system to link it to a person.
+    A physical credential can be attached after provisioning.
+  </p>
+  <form method="POST" action="/admin/ui/members">
+    <div class="form-group">
+      <label for="role_id">Role <span style="color:var(--red)">*</span></label>
+      <select id="role_id" name="role_id" required>
+        <option value="">— Select a role —</option>
+        {{range .Roles}}
+        <option value="{{.RoleID}}" {{if eq .RoleID $.Form.role_id}}selected{{end}}>{{.Name}}</option>
+        {{end}}
+      </select>
+    </div>
+    <div class="form-group">
+      <label for="expires_at">Hard Expiry Date (optional)</label>
+      <input id="expires_at" name="expires_at" type="date" value="{{.Form.expires_at}}">
+      <p class="hint">Leave blank for no hard deadline. Member is transitioned to <em>expired</em> at midnight UTC on this date.</p>
+    </div>
+    <div class="form-group">
+      <label for="inactivity_limit_days">Inactivity Limit (days, optional)</label>
+      <input id="inactivity_limit_days" name="inactivity_limit_days" type="number" min="1"
+        value="{{.Form.inactivity_limit_days}}" placeholder="e.g. 90">
+      <p class="hint">Leave blank to disable inactivity-based expiry.</p>
+    </div>
+    <div class="actions">
+      <button class="btn btn-primary" type="submit">Provision Member</button>
+      <a class="btn btn-secondary" href="/admin/ui/members">Cancel</a>
+    </div>
+  </form>
+</div>
+{{end}}

--- a/server/internal/httpapi/ui.go
+++ b/server/internal/httpapi/ui.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/permissions"
 	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/service"
+	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/types"
 )
 
 //go:embed templates static
@@ -37,6 +38,21 @@ type UIPageData struct {
 	PermGroups []PermGroup
 	Form       map[string]string
 	MustChange bool
+
+	// Member management pages.
+	Members        []types.MemberInfo
+	Member         *types.MemberInfo
+	Authorizations []types.ModuleAuthorizationInfo
+	AccessEvents   []UIAccessEventInfo
+	Modules        []types.ModuleInfo
+}
+
+// UIAccessEventInfo is a display-ready view of a single access event.
+type UIAccessEventInfo struct {
+	ModuleID   string
+	ReceivedAt string
+	Granted    bool
+	Reason     string
 }
 
 // HasPerm returns true if the given permission is in Role.Permissions.

--- a/server/internal/httpapi/ui_members.go
+++ b/server/internal/httpapi/ui_members.go
@@ -1,0 +1,456 @@
+package httpapi
+
+import (
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/permissions"
+	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/service"
+	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/store"
+	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/types"
+)
+
+// ── List ─────────────────────────────────────────────────────────────────────
+
+// handleUIMembersList serves GET /admin/ui/members.
+func (s *Server) handleUIMembersList(w http.ResponseWriter, r *http.Request) {
+	d := newUIPageData(r, "members")
+
+	recs, err := s.memberAccessService.ListMembers(r.Context())
+	if err != nil {
+		s.logger.Printf("ui list members: %v", err)
+		d.Flash = "Failed to load members."
+		d.FlashType = "error"
+	} else {
+		d.Members = memberRecsToInfos(recs)
+	}
+
+	render.render(w, "members_list", d)
+}
+
+// handleUIMembersPending serves GET /admin/ui/members/pending.
+func (s *Server) handleUIMembersPending(w http.ResponseWriter, r *http.Request) {
+	d := newUIPageData(r, "members")
+
+	recs, err := s.memberAccessService.ListPendingAuthorizations(r.Context())
+	if err != nil {
+		s.logger.Printf("ui list pending authorizations: %v", err)
+		d.Flash = "Failed to load pending authorizations."
+		d.FlashType = "error"
+	} else {
+		d.Members = memberRecsToInfos(recs)
+	}
+
+	render.render(w, "members_pending", d)
+}
+
+// ── Detail ────────────────────────────────────────────────────────────────────
+
+// handleUIMembersDetail serves GET /admin/ui/members/{member_uuid}.
+func (s *Server) handleUIMembersDetail(w http.ResponseWriter, r *http.Request) {
+	memberUUID := r.PathValue("member_uuid")
+	d := newUIPageData(r, "members")
+
+	rec, err := s.memberAccessService.GetMember(r.Context(), memberUUID)
+	if err != nil {
+		if errors.Is(err, service.ErrMemberNotFound) {
+			http.NotFound(w, r)
+			return
+		}
+		s.logger.Printf("ui get member: %v", err)
+		flashRedirect(w, r, "/admin/ui/members", "Failed to load member.", "error")
+		return
+	}
+	info := memberRecordToInfo(rec)
+	d.Member = &info
+
+	// Module authorizations for this member.
+	authRecs, err := s.moduleAuthService.ListByMember(r.Context(), memberUUID)
+	if err != nil {
+		s.logger.Printf("ui list authorizations for member %s: %v", memberUUID, err)
+	} else {
+		d.Authorizations = make([]types.ModuleAuthorizationInfo, len(authRecs))
+		for i := range authRecs {
+			d.Authorizations[i] = moduleAuthRecordToInfo(&authRecs[i])
+		}
+	}
+
+	// All modules — used by the grant-authorization form.
+	if s.adminService != nil {
+		mods, err := s.adminService.ListModules(r.Context())
+		if err != nil {
+			s.logger.Printf("ui list modules for grant form: %v", err)
+		} else {
+			d.Modules = mods
+		}
+	}
+
+	// All roles — used by the assign-role form.
+	roles, err := s.roleService.ListRoles(r.Context())
+	if err != nil {
+		s.logger.Printf("ui list roles for member detail: %v", err)
+	} else {
+		d.Roles = roles
+	}
+
+	// Recent access events (only if a credential is attached).
+	if len(rec.CredentialHash) == 32 && s.accessService != nil {
+		events, err := s.accessService.ListEventsByCredential(r.Context(), rec.CredentialHash, 50)
+		if err != nil {
+			s.logger.Printf("ui list access events for member %s: %v", memberUUID, err)
+		} else {
+			d.AccessEvents = accessEventsToUI(events)
+		}
+	}
+
+	render.render(w, "members_detail", d)
+}
+
+// ── Provision ─────────────────────────────────────────────────────────────────
+
+// handleUIMembersNew serves GET /admin/ui/members/new.
+func (s *Server) handleUIMembersNew(w http.ResponseWriter, r *http.Request) {
+	d := newUIPageData(r, "members")
+
+	roles, err := s.roleService.ListRoles(r.Context())
+	if err != nil {
+		s.logger.Printf("ui new member: list roles: %v", err)
+		d.Flash = "Failed to load roles."
+		d.FlashType = "error"
+	}
+	d.Roles = roles
+
+	render.render(w, "members_provision", d)
+}
+
+// handleUIMembersCreate handles POST /admin/ui/members.
+func (s *Server) handleUIMembersCreate(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		flashRedirect(w, r, "/admin/ui/members/new", "Invalid form submission.", "error")
+		return
+	}
+
+	roleID := r.FormValue("role_id")
+	expiresAtStr := r.FormValue("expires_at")
+	inactivityStr := r.FormValue("inactivity_limit_days")
+
+	var expiresAt *time.Time
+	if expiresAtStr != "" {
+		t, err := time.Parse("2006-01-02", expiresAtStr)
+		if err != nil {
+			flashRedirect(w, r, "/admin/ui/members/new", "Invalid expiry date format (use YYYY-MM-DD).", "error")
+			return
+		}
+		u := t.UTC()
+		expiresAt = &u
+	}
+
+	var inactivityDays *int
+	if inactivityStr != "" {
+		var n int
+		if _, err := parseIntFormValue(inactivityStr, &n); err != nil || n < 1 {
+			flashRedirect(w, r, "/admin/ui/members/new", "Inactivity limit must be a positive number.", "error")
+			return
+		}
+		inactivityDays = &n
+	}
+
+	sess := sessionFromContext(r.Context())
+	createdBy := ""
+	if sess != nil {
+		createdBy = sess.AdminUUID
+	}
+
+	rec, err := s.memberAccessService.ProvisionMember(r.Context(), roleID, createdBy, expiresAt, inactivityDays)
+	if err != nil {
+		if errors.Is(err, service.ErrRoleIDRequired) {
+			flashRedirect(w, r, "/admin/ui/members/new", "A role is required.", "error")
+			return
+		}
+		if errors.Is(err, store.ErrNotFound) {
+			flashRedirect(w, r, "/admin/ui/members/new", "Selected role does not exist.", "error")
+			return
+		}
+		s.logger.Printf("ui provision member: %v", err)
+		flashRedirect(w, r, "/admin/ui/members/new", "Failed to provision member.", "error")
+		return
+	}
+
+	s.logger.Printf("admin ui: provisioned member uuid=%s role=%s by=%s", rec.UUID, rec.RoleID, createdBy)
+	http.Redirect(w, r, "/admin/ui/members/"+rec.UUID+"?flash=Member+provisioned.+Copy+UUID+below.&ft=success", http.StatusSeeOther)
+}
+
+// ── Actions ───────────────────────────────────────────────────────────────────
+
+// handleUIMembersAttachCredential handles POST /admin/ui/members/{member_uuid}/credential.
+func (s *Server) handleUIMembersAttachCredential(w http.ResponseWriter, r *http.Request) {
+	memberUUID := r.PathValue("member_uuid")
+	if err := r.ParseForm(); err != nil {
+		flashRedirect(w, r, "/admin/ui/members/"+memberUUID, "Invalid form submission.", "error")
+		return
+	}
+
+	hashHex := r.FormValue("credential_hash")
+	credHash, err := hex.DecodeString(hashHex)
+	if err != nil || len(credHash) != 32 {
+		flashRedirect(w, r, "/admin/ui/members/"+memberUUID, "Credential hash must be 64 hex characters (32 bytes).", "error")
+		return
+	}
+
+	if err := s.memberAccessService.AttachCredential(r.Context(), memberUUID, credHash); err != nil {
+		msg := "Failed to attach credential."
+		switch {
+		case errors.Is(err, service.ErrMemberNotFound):
+			http.NotFound(w, r)
+			return
+		case errors.Is(err, service.ErrDuplicateCredentialActive):
+			msg = "That credential is already assigned to an active member."
+		case errors.Is(err, service.ErrDuplicateCredentialPending):
+			msg = "That credential is already attached to a pending member — resolve the pending record first."
+		case errors.Is(err, service.ErrDuplicateCredentialInactive):
+			msg = "That credential belongs to an expired or archived member."
+		default:
+			s.logger.Printf("ui attach credential: %v", err)
+		}
+		flashRedirect(w, r, "/admin/ui/members/"+memberUUID, msg, "error")
+		return
+	}
+
+	s.logger.Printf("admin ui: attached credential to member %s", memberUUID)
+	flashRedirect(w, r, "/admin/ui/members/"+memberUUID, "Credential attached.", "success")
+}
+
+// handleUIMembersAssignRole handles POST /admin/ui/members/{member_uuid}/role.
+func (s *Server) handleUIMembersAssignRole(w http.ResponseWriter, r *http.Request) {
+	memberUUID := r.PathValue("member_uuid")
+	if err := r.ParseForm(); err != nil {
+		flashRedirect(w, r, "/admin/ui/members/"+memberUUID, "Invalid form submission.", "error")
+		return
+	}
+
+	roleID := r.FormValue("role_id")
+	if err := s.memberAccessService.AssignRole(r.Context(), memberUUID, roleID); err != nil {
+		switch {
+		case errors.Is(err, service.ErrMemberNotFound):
+			http.NotFound(w, r)
+			return
+		case errors.Is(err, service.ErrRoleIDRequired):
+			flashRedirect(w, r, "/admin/ui/members/"+memberUUID, "A role is required.", "error")
+			return
+		case errors.Is(err, store.ErrNotFound):
+			flashRedirect(w, r, "/admin/ui/members/"+memberUUID, "Selected role does not exist.", "error")
+			return
+		default:
+			s.logger.Printf("ui assign role to member %s: %v", memberUUID, err)
+			flashRedirect(w, r, "/admin/ui/members/"+memberUUID, "Failed to assign role.", "error")
+			return
+		}
+	}
+
+	s.logger.Printf("admin ui: assigned role %q to member %s", roleID, memberUUID)
+	flashRedirect(w, r, "/admin/ui/members/"+memberUUID, "Role updated.", "success")
+}
+
+// handleUIMembersDisable handles POST /admin/ui/members/{member_uuid}/disable.
+func (s *Server) handleUIMembersDisable(w http.ResponseWriter, r *http.Request) {
+	memberUUID := r.PathValue("member_uuid")
+	if err := s.memberAccessService.Disable(r.Context(), memberUUID); err != nil {
+		if errors.Is(err, service.ErrMemberNotFound) {
+			http.NotFound(w, r)
+			return
+		}
+		s.logger.Printf("ui disable member %s: %v", memberUUID, err)
+		flashRedirect(w, r, "/admin/ui/members/"+memberUUID, "Failed to disable member.", "error")
+		return
+	}
+	s.logger.Printf("admin ui: disabled member %s", memberUUID)
+	flashRedirect(w, r, "/admin/ui/members/"+memberUUID, "Member disabled.", "success")
+}
+
+// handleUIMembersEnable handles POST /admin/ui/members/{member_uuid}/enable.
+func (s *Server) handleUIMembersEnable(w http.ResponseWriter, r *http.Request) {
+	memberUUID := r.PathValue("member_uuid")
+	if err := s.memberAccessService.Enable(r.Context(), memberUUID); err != nil {
+		if errors.Is(err, service.ErrMemberNotFound) {
+			http.NotFound(w, r)
+			return
+		}
+		s.logger.Printf("ui enable member %s: %v", memberUUID, err)
+		flashRedirect(w, r, "/admin/ui/members/"+memberUUID, "Failed to enable member.", "error")
+		return
+	}
+	s.logger.Printf("admin ui: enabled member %s", memberUUID)
+	flashRedirect(w, r, "/admin/ui/members/"+memberUUID, "Member enabled.", "success")
+}
+
+// handleUIMembersArchive handles POST /admin/ui/members/{member_uuid}/archive.
+func (s *Server) handleUIMembersArchive(w http.ResponseWriter, r *http.Request) {
+	memberUUID := r.PathValue("member_uuid")
+	sess := sessionFromContext(r.Context())
+	archivedBy := ""
+	if sess != nil {
+		archivedBy = sess.AdminUUID
+	}
+
+	if err := s.memberAccessService.Archive(r.Context(), memberUUID, archivedBy); err != nil {
+		if errors.Is(err, service.ErrMemberNotFound) {
+			http.NotFound(w, r)
+			return
+		}
+		s.logger.Printf("ui archive member %s: %v", memberUUID, err)
+		flashRedirect(w, r, "/admin/ui/members/"+memberUUID, "Failed to archive member.", "error")
+		return
+	}
+	s.logger.Printf("admin ui: archived member %s by %s", memberUUID, archivedBy)
+	flashRedirect(w, r, "/admin/ui/members", "Member archived.", "success")
+}
+
+// ── Module Authorizations ─────────────────────────────────────────────────────
+
+// handleUIGrantAuthorization handles POST /admin/ui/members/{member_uuid}/authorizations.
+func (s *Server) handleUIGrantAuthorization(w http.ResponseWriter, r *http.Request) {
+	memberUUID := r.PathValue("member_uuid")
+	if err := r.ParseForm(); err != nil {
+		flashRedirect(w, r, "/admin/ui/members/"+memberUUID, "Invalid form submission.", "error")
+		return
+	}
+
+	moduleID := r.FormValue("module_id")
+	expiresAtStr := r.FormValue("expires_at")
+
+	var expiresAt *time.Time
+	if expiresAtStr != "" {
+		t, err := time.Parse("2006-01-02", expiresAtStr)
+		if err != nil {
+			flashRedirect(w, r, "/admin/ui/members/"+memberUUID, "Invalid expiry date format (use YYYY-MM-DD).", "error")
+			return
+		}
+		u := t.UTC()
+		expiresAt = &u
+	}
+
+	sess := sessionFromContext(r.Context())
+	grantedBy := ""
+	if sess != nil {
+		grantedBy = sess.AdminUUID
+	}
+
+	if err := s.moduleAuthService.GrantAuthorization(r.Context(), memberUUID, moduleID, grantedBy, expiresAt, ""); err != nil {
+		msg := "Failed to grant authorization."
+		switch {
+		case errors.Is(err, service.ErrAuthorizationAlreadyExists):
+			msg = "An active authorization already exists for that module."
+		case errors.Is(err, service.ErrMemberUUIDRequired), errors.Is(err, service.ErrModuleIDRequired):
+			msg = "Member UUID and module are required."
+		default:
+			s.logger.Printf("ui grant authorization member=%s module=%s: %v", memberUUID, moduleID, err)
+		}
+		flashRedirect(w, r, "/admin/ui/members/"+memberUUID, msg, "error")
+		return
+	}
+
+	s.logger.Printf("admin ui: granted authorization member=%s module=%s by=%s", memberUUID, moduleID, grantedBy)
+	flashRedirect(w, r, "/admin/ui/members/"+memberUUID, "Module authorization granted.", "success")
+}
+
+// handleUIRevokeAuthorization handles POST /admin/ui/members/{member_uuid}/authorizations/{module_id}/revoke.
+func (s *Server) handleUIRevokeAuthorization(w http.ResponseWriter, r *http.Request) {
+	memberUUID := r.PathValue("member_uuid")
+	moduleID := r.PathValue("module_id")
+
+	sess := sessionFromContext(r.Context())
+	revokedBy := ""
+	if sess != nil {
+		revokedBy = sess.AdminUUID
+	}
+
+	if err := s.moduleAuthService.RevokeAuthorization(r.Context(), memberUUID, moduleID, revokedBy); err != nil {
+		if errors.Is(err, service.ErrAuthorizationNotFound) {
+			flashRedirect(w, r, "/admin/ui/members/"+memberUUID, "No active authorization found for that module.", "error")
+			return
+		}
+		s.logger.Printf("ui revoke authorization member=%s module=%s: %v", memberUUID, moduleID, err)
+		flashRedirect(w, r, "/admin/ui/members/"+memberUUID, "Failed to revoke authorization.", "error")
+		return
+	}
+
+	s.logger.Printf("admin ui: revoked authorization member=%s module=%s by=%s", memberUUID, moduleID, revokedBy)
+	flashRedirect(w, r, "/admin/ui/members/"+memberUUID, "Authorization revoked.", "success")
+}
+
+// ── Route registration ────────────────────────────────────────────────────────
+
+// uiMemberRoutes registers all /admin/ui/members/* routes on the given mux.
+func (s *Server) uiMemberRoutes(mux *http.ServeMux) {
+	perm := requireUIPermission
+
+	// List + pending queue
+	mux.HandleFunc("GET /admin/ui/members",
+		perm(permissions.MemberList, s.handleUIMembersList))
+	mux.HandleFunc("GET /admin/ui/members/pending",
+		perm(permissions.MemberList, s.handleUIMembersPending))
+
+	// Provision new member (must be registered before /{member_uuid} to avoid ambiguity)
+	mux.HandleFunc("GET /admin/ui/members/new",
+		perm(permissions.MemberProvision, s.handleUIMembersNew))
+	mux.HandleFunc("POST /admin/ui/members",
+		perm(permissions.MemberProvision, s.handleUIMembersCreate))
+
+	// Member detail + actions
+	mux.HandleFunc("GET /admin/ui/members/{member_uuid}",
+		perm(permissions.MemberView, s.handleUIMembersDetail))
+	mux.HandleFunc("POST /admin/ui/members/{member_uuid}/credential",
+		perm(permissions.MemberProvision, s.handleUIMembersAttachCredential))
+	mux.HandleFunc("POST /admin/ui/members/{member_uuid}/role",
+		perm(permissions.MemberAssignRole, s.handleUIMembersAssignRole))
+	mux.HandleFunc("POST /admin/ui/members/{member_uuid}/disable",
+		perm(permissions.MemberDisable, s.handleUIMembersDisable))
+	mux.HandleFunc("POST /admin/ui/members/{member_uuid}/enable",
+		perm(permissions.MemberDisable, s.handleUIMembersEnable))
+	mux.HandleFunc("POST /admin/ui/members/{member_uuid}/archive",
+		perm(permissions.MemberArchive, s.handleUIMembersArchive))
+
+	// Module authorization grant/revoke
+	mux.HandleFunc("POST /admin/ui/members/{member_uuid}/authorizations",
+		perm(permissions.ModuleAuthGrant, s.handleUIGrantAuthorization))
+	mux.HandleFunc("POST /admin/ui/members/{member_uuid}/authorizations/{module_id}/revoke",
+		perm(permissions.ModuleAuthRevoke, s.handleUIRevokeAuthorization))
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+func memberRecsToInfos(recs []store.MemberAccessRecord) []types.MemberInfo {
+	out := make([]types.MemberInfo, len(recs))
+	for i := range recs {
+		out[i] = memberRecordToInfo(&recs[i])
+	}
+	return out
+}
+
+func accessEventsToUI(recs []store.AccessEventRecord) []UIAccessEventInfo {
+	out := make([]UIAccessEventInfo, len(recs))
+	for i, r := range recs {
+		out[i] = UIAccessEventInfo{
+			ModuleID:   r.ModuleID,
+			ReceivedAt: r.ReceivedAt.Format("2006-01-02 15:04:05 UTC"),
+			Granted:    r.Granted,
+			Reason:     r.Reason,
+		}
+	}
+	return out
+}
+
+// parseIntFormValue parses a decimal integer from a form string into *dst.
+func parseIntFormValue(s string, dst *int) (int, error) {
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, errors.New("not a number")
+		}
+		n = n*10 + int(c-'0')
+	}
+	*dst = n
+	return n, nil
+}

--- a/server/internal/portunus/service/access_service.go
+++ b/server/internal/portunus/service/access_service.go
@@ -181,6 +181,12 @@ func (s *AccessService) recordEvent(
 	_ = s.eventStore.RecordEvent(ctx, rec)
 }
 
+// ListEventsByCredential returns recent access events for the given credential
+// hash, newest-first, capped at limit rows. Used by the member detail UI.
+func (s *AccessService) ListEventsByCredential(ctx context.Context, credentialHash []byte, limit int) ([]store.AccessEventRecord, error) {
+	return s.eventStore.ListEventsByCredential(ctx, credentialHash, limit)
+}
+
 // decideMemberAccess checks member_access + module_authorizations and returns
 // (granted, reason, memberUUID, error). memberUUID is non-empty only on grant.
 func (s *AccessService) decideMemberAccess(

--- a/server/internal/portunus/store/access_event_store.go
+++ b/server/internal/portunus/store/access_event_store.go
@@ -20,4 +20,7 @@ type AccessEventRecord struct {
 // AccessEventStore persists access decisions as an append-only audit log.
 type AccessEventStore interface {
 	RecordEvent(ctx context.Context, rec AccessEventRecord) error
+	// ListEventsByCredential returns the most recent events for the given
+	// credential hash, newest-first, capped at limit rows.
+	ListEventsByCredential(ctx context.Context, credentialHash []byte, limit int) ([]AccessEventRecord, error)
 }

--- a/server/internal/portunus/store/memory/access_event_store.go
+++ b/server/internal/portunus/store/memory/access_event_store.go
@@ -25,6 +25,32 @@ func (s *AccessEventStore) RecordEvent(_ context.Context, rec store.AccessEventR
 	return nil
 }
 
+func (s *AccessEventStore) ListEventsByCredential(_ context.Context, credentialHash []byte, limit int) ([]store.AccessEventRecord, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if limit <= 0 {
+		limit = 50
+	}
+	var out []store.AccessEventRecord
+	// Iterate newest-first (events are appended, so reverse order).
+	for i := len(s.events) - 1; i >= 0 && len(out) < limit; i-- {
+		e := s.events[i]
+		if len(e.CredentialHash) == len(credentialHash) {
+			match := true
+			for j := range credentialHash {
+				if e.CredentialHash[j] != credentialHash[j] {
+					match = false
+					break
+				}
+			}
+			if match {
+				out = append(out, e)
+			}
+		}
+	}
+	return out, nil
+}
+
 // Events returns a copy of all recorded events.  Test-only helper.
 func (s *AccessEventStore) Events() []store.AccessEventRecord {
 	s.mu.Lock()

--- a/server/internal/portunus/store/sqlite/access_event_store.go
+++ b/server/internal/portunus/store/sqlite/access_event_store.go
@@ -19,6 +19,56 @@ func NewAccessEventStore(db *sql.DB, writer *dbpkg.Worker) *AccessEventStore {
 	return &AccessEventStore{db: db, writer: writer}
 }
 
+func (s *AccessEventStore) ListEventsByCredential(ctx context.Context, credentialHash []byte, limit int) ([]store.AccessEventRecord, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := s.db.QueryContext(ctx, `
+SELECT module_id, received_at_ms, requested_at_ms, door_closed,
+       credential_hash, decision_granted, decision_reason, decided_at_ms
+FROM access_events
+WHERE credential_hash = ?
+ORDER BY received_at_ms DESC
+LIMIT ?;
+`, credentialHash, limit)
+	if err != nil {
+		return nil, fmt.Errorf("ListEventsByCredential query: %w", err)
+	}
+	defer rows.Close()
+
+	var out []store.AccessEventRecord
+	for rows.Next() {
+		var rec store.AccessEventRecord
+		var receivedMs, decidedMs int64
+		var requestedMs sql.NullInt64
+		var doorClosed sql.NullInt64
+		var granted int
+		var credHash []byte
+
+		if err := rows.Scan(
+			&rec.ModuleID, &receivedMs, &requestedMs, &doorClosed,
+			&credHash, &granted, &rec.Reason, &decidedMs,
+		); err != nil {
+			return nil, fmt.Errorf("ListEventsByCredential scan: %w", err)
+		}
+
+		rec.ReceivedAt = time.UnixMilli(receivedMs).UTC()
+		rec.DecidedAt = time.UnixMilli(decidedMs).UTC()
+		if requestedMs.Valid {
+			t := time.UnixMilli(requestedMs.Int64).UTC()
+			rec.RequestedAt = &t
+		}
+		if doorClosed.Valid {
+			b := doorClosed.Int64 != 0
+			rec.DoorClosed = &b
+		}
+		rec.Granted = granted != 0
+		rec.CredentialHash = credHash
+		out = append(out, rec)
+	}
+	return out, rows.Err()
+}
+
 func (s *AccessEventStore) RecordEvent(ctx context.Context, rec store.AccessEventRecord) error {
 	if rec.ReceivedAt.IsZero() {
 		rec.ReceivedAt = time.Now().UTC()


### PR DESCRIPTION
Store layer — extended AccessEventStore interface with ListEventsByCredential, implemented in both the SQLite store ([sqlite/access_event_store.go](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/server/internal/portunus/store/sqlite/access_event_store.go)) and memory store ([memory/access_event_store.go](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/server/internal/portunus/store/memory/access_event_store.go)).

Service layer — ListEventsByCredential added to AccessService ([service/access_service.go](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/server/internal/portunus/service/access_service.go)) so the HTTP layer can query access history without direct store access.

UI layer (new file) — [httpapi/ui_members.go](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/server/internal/httpapi/ui_members.go) with 11 handlers covering the full member lifecycle:

List all members / pending queue
Provision (direct-issue path), detail view
Attach credential, assign role, disable/enable, archive
Grant + revoke module authorization
uiMemberRoutes() registers all routes under /admin/ui/members/…
Templates (4 new files):

[members_list.html](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/server/internal/httpapi/templates/members_list.html) — table with status badges and UUID display
[members_pending.html](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/server/internal/httpapi/templates/members_pending.html) — FIFO pending queue with copy-UUID button
[members_detail.html](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/server/internal/httpapi/templates/members_detail.html) — full detail page: identity, copy-UUID button, actions section, module authorizations (grant/revoke inline), access event history
[members_provision.html](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/server/internal/httpapi/templates/members_provision.html) — provision form with role selector, optional expiry, optional inactivity limit
Wiring — uiMemberRoutes called in [server.go](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/server/internal/httpapi/server.go), Members/Pending nav links added to [base.html](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/server/internal/httpapi/templates/base.html), UIPageData extended with Members, Member, Authorizations, AccessEvents, and Modules fields.