### PR TITLE
add FSM logic for provision console

### DIFF
--- a/access_module/components/portunus_interfaces/include/i_feedback.h
+++ b/access_module/components/portunus_interfaces/include/i_feedback.h
@@ -37,6 +37,13 @@ enum class feedback_type_t : uint8_t {
     SYSTEM_READY,       /**< Operational idle (continuous until replaced) */
     SYSTEM_ERROR,       /**< Error state (continuous until replaced) */
     CARD_READ,          /**< Card detected, awaiting server (held until replaced) */
+
+    /* Provisioning console states (PROVISIONING_CONSOLE firmware only) */
+    PROVISIONING_IDLE,          /**< Awaiting operator scan — double heartbeat pulse (continuous) */
+    PROVISIONING_AWAITING,      /**< Operator scan done, awaiting new credential — slow 50/50 pulse (continuous) */
+    PROVISIONING_SUCCESS,       /**< Provisioning succeeded — 5× rapid blinks (one-shot) */
+    PROVISIONING_DUPLICATE,     /**< Credential already exists — 2× medium blinks (one-shot) */
+    PROVISIONING_UNAUTHORIZED,  /**< Operator not authorised — long on + 3× rapid blinks (one-shot) */
 };
 
 /**

--- a/access_module/components/portunus_types/include/event_types.h
+++ b/access_module/components/portunus_types/include/event_types.h
@@ -47,6 +47,11 @@ typedef enum {
 
     /* FSM command events: 0x05xx */
     EVENT_FSM_UNLOCK_TIMEOUT = 0x0500,/**< FSM unlock hold timer expired */
+
+    /* Provisioning events: 0x06xx (PROVISIONING_CONSOLE firmware only) */
+    EVENT_PROVISION_REQUEST = 0x0600, /**< FSM requests a provisioning call */
+    EVENT_PROVISION_SUCCESS,           /**< Server confirmed provisioning */
+    EVENT_PROVISION_FAILED,            /**< Server rejected provisioning */
 } portunus_event_id_t;
 
 /* ── Event payloads ────────────────────────────────────────────────────────── */
@@ -89,6 +94,44 @@ typedef struct {
     int64_t timestamp_ms;         /**< When the transition occurred */
 } event_door_state_t;
 
+/**
+ * @brief Result reason codes for EVENT_PROVISION_SUCCESS / EVENT_PROVISION_FAILED.
+ *
+ * Mirrors portunus_v1_ProvisionStatus without pulling in the nanopb header.
+ */
+typedef enum {
+    PROVISION_RESULT_SUCCESS            = 0,
+    PROVISION_RESULT_DUPLICATE_ACTIVE   = 1,
+    PROVISION_RESULT_DUPLICATE_INACTIVE = 2,
+    PROVISION_RESULT_DUPLICATE_PENDING  = 3,
+    PROVISION_RESULT_UNAUTHORIZED       = 4,
+    PROVISION_RESULT_INVALID_ROLE       = 5,
+    PROVISION_RESULT_COMM_ERROR         = 6,  /**< Transport / encode / decode failure */
+} provision_result_reason_t;
+
+/**
+ * @brief Payload for EVENT_PROVISION_REQUEST.
+ *
+ * Published by ProvisioningFSM when both scans complete.
+ * server_comm encodes this into a ProvisionCredentialRequest and sends it.
+ */
+typedef struct {
+    char    operator_uuid[37];    /**< Pre-configured operator UUID (from Kconfig) */
+    uint8_t credential_hash[32];  /**< SHA-256 of the new credential's raw UID bytes */
+    char    role_id[33];          /**< Role ID to assign to the new member */
+} event_provision_request_t;
+
+/**
+ * @brief Payload for EVENT_PROVISION_SUCCESS and EVENT_PROVISION_FAILED.
+ *
+ * Published by server_comm after the server responds to ProvisionCredentialRequest.
+ */
+typedef struct {
+    char                      member_uuid[37]; /**< Assigned UUID — non-empty on SUCCESS */
+    provision_result_reason_t reason;
+    char                      detail[64];      /**< Human-readable detail from server */
+} event_provision_result_t;
+
 /* ── Generic event envelope ────────────────────────────────────────────────── */
 
 /**
@@ -106,6 +149,8 @@ typedef struct {
         event_access_decision_t   access_decision;
         event_door_state_t        door_opened;
         event_door_state_t        door_closed;
+        event_provision_request_t provision_request;
+        event_provision_result_t  provision_result;
     } payload;
 } portunus_event_t;
 

--- a/access_module/core/provisioning_fsm/CMakeLists.txt
+++ b/access_module/core/provisioning_fsm/CMakeLists.txt
@@ -1,10 +1,18 @@
 # core/provisioning_fsm — Two-scan provisioning console FSM
 #
-# Built only when CONFIG_PORTUNUS_MODULE_TYPE_PROVISIONING_CONSOLE=y.
-# Requires mbedtls for SHA-256 credential hashing.
+# provisioning_fsm.cpp is only compiled when the PROVISIONING_CONSOLE variant
+# is selected.  The component is still registered (with empty SRCS) for the
+# ACCESS_POINT build so that nothing in EXTRA_COMPONENT_DIRS breaks CMake
+# dependency resolution.  This mirrors the pattern used by grpc_client.
+
+if(CONFIG_PORTUNUS_MODULE_TYPE_PROVISIONING_CONSOLE)
+    set(_prov_srcs "src/provisioning_fsm.cpp")
+else()
+    set(_prov_srcs "")
+endif()
 
 idf_component_register(
-    SRCS "src/provisioning_fsm.cpp"
+    SRCS ${_prov_srcs}
     INCLUDE_DIRS "include"
     REQUIRES
         portunus_interfaces

--- a/access_module/core/provisioning_fsm/CMakeLists.txt
+++ b/access_module/core/provisioning_fsm/CMakeLists.txt
@@ -1,0 +1,18 @@
+# core/provisioning_fsm — Two-scan provisioning console FSM
+#
+# Built only when CONFIG_PORTUNUS_MODULE_TYPE_PROVISIONING_CONSOLE=y.
+# Requires mbedtls for SHA-256 credential hashing.
+
+idf_component_register(
+    SRCS "src/provisioning_fsm.cpp"
+    INCLUDE_DIRS "include"
+    REQUIRES
+        portunus_interfaces
+        portunus_types
+    PRIV_REQUIRES
+        event_bus
+        freertos
+        esp_timer
+        wifi_mgr
+        mbedtls
+)

--- a/access_module/core/provisioning_fsm/include/provisioning_fsm.h
+++ b/access_module/core/provisioning_fsm/include/provisioning_fsm.h
@@ -1,0 +1,122 @@
+/**
+ * @file provisioning_fsm.h
+ * @brief Provisioning console FSM — two-scan credential enrollment orchestrator.
+ *
+ * Implements the PROVISIONING_CONSOLE firmware variant FSM:
+ *
+ *   IDLE ──(any credential read)──► AWAITING_CREDENTIAL
+ *                                        │  (30s timeout)
+ *                                        ▼
+ *                                   ──(timeout)──► IDLE
+ *                                        │
+ *                                   (new credential read)
+ *                                        │
+ *                                        ▼
+ *                                      SENDING
+ *                                   (EVENT_PROVISION_REQUEST published)
+ *                                        │
+ *                          ┌─────────────┴──────────────┐
+ *                      SUCCESS                        FAILED
+ *                          │                             │
+ *                        IDLE ◄──────────────────────── IDLE
+ *
+ * Scan 1 (in IDLE): any credential read advances the FSM and starts the
+ * mandatory timeout. The credential is discarded — it serves only as a
+ * physical presence confirmation.
+ *
+ * Scan 2 (in AWAITING_CREDENTIAL): the new credential's raw UID bytes are
+ * SHA-256 hashed on-device via mbedTLS. The hash, the pre-configured
+ * operator UUID (Kconfig), and the default role ID are bundled into an
+ * EVENT_PROVISION_REQUEST and published to the event bus. server_comm
+ * encodes and sends the ProvisionCredentialRequest RPC.
+ *
+ * Architecture layer: Core / FSM (mirrors system_fsm architecture).
+ */
+
+#pragma once
+
+#include "event_types.h"
+#include "i_credential_reader.h"
+#include "i_feedback.h"
+#include "portunus_types.h"
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/queue.h"
+
+/**
+ * @brief Provisioning FSM internal state.
+ */
+typedef enum {
+    PROV_STATE_IDLE,                 /**< Awaiting operator scan */
+    PROV_STATE_AWAITING_CREDENTIAL,  /**< Operator scan done, waiting for new credential */
+    PROV_STATE_SENDING,              /**< Request sent, waiting for server response */
+} prov_state_t;
+
+/**
+ * @brief Provisioning console FSM.
+ *
+ * Drop-in replacement for SystemFSM when built with
+ * CONFIG_PORTUNUS_MODULE_TYPE_PROVISIONING_CONSOLE.
+ * Requires a credential reader and feedback LED; no access point needed.
+ */
+class ProvisioningFSM {
+public:
+    /**
+     * @param reader   Credential reader (must not be nullptr).
+     * @param feedback Feedback module (nullptr disables LED indication).
+     */
+    ProvisioningFSM(ICredentialReader *reader, IFeedback *feedback);
+
+    /**
+     * @brief Initialise modules and set capability flags.
+     * @return PORTUNUS_OK on success.
+     */
+    portunus_err_t init();
+
+    /**
+     * @brief Start the FSM task and credential polling sub-task.
+     *
+     * Must be called after init() and after event_bus_init().
+     * @return PORTUNUS_OK on success.
+     */
+    portunus_err_t start();
+
+    /** @brief Current provisioning FSM state. */
+    prov_state_t state() const { return m_prov_state; }
+
+private:
+    /* ── Injected dependencies ────────────────────────────────────────────── */
+    ICredentialReader *m_reader;
+    IFeedback         *m_feedback;
+
+    /* ── Capability flags ─────────────────────────────────────────────────── */
+    bool m_has_reader   = false;
+    bool m_has_feedback = false;
+    bool m_has_network  = false;
+
+    /* ── FSM state ────────────────────────────────────────────────────────── */
+    prov_state_t m_prov_state        = PROV_STATE_IDLE;
+    int64_t      m_timeout_deadline_ms = 0;
+
+    /* ── FreeRTOS handles ─────────────────────────────────────────────────── */
+    TaskHandle_t  m_fsm_task_handle  = nullptr;
+    TaskHandle_t  m_poll_task_handle = nullptr;
+    QueueHandle_t m_event_queue      = nullptr;
+
+    /* ── Task entry points ────────────────────────────────────────────────── */
+    static void fsm_task_entry(void *arg);
+    static void credential_poll_task_entry(void *arg);
+
+    /* ── Internal methods ─────────────────────────────────────────────────── */
+    void run();
+    void poll_credential();
+    void process_event(const portunus_event_t &event);
+    void handle_credential_read(const event_credential_read_t *cred);
+    void handle_provision_result(const event_provision_result_t *result);
+    void handle_timeout();
+    void transition_to_idle();
+
+    /* ── Event bus bridge ─────────────────────────────────────────────────── */
+    static void on_event_bus_event(const portunus_event_t *event, void *ctx);
+};

--- a/access_module/core/provisioning_fsm/src/provisioning_fsm.cpp
+++ b/access_module/core/provisioning_fsm/src/provisioning_fsm.cpp
@@ -1,0 +1,429 @@
+/**
+ * @file provisioning_fsm.cpp
+ * @brief Provisioning console FSM implementation.
+ *
+ * Two-scan flow:
+ *   1. Any credential read in IDLE → start 30s timeout, move to AWAITING.
+ *   2. Any credential read in AWAITING → compute SHA-256(uid), publish
+ *      EVENT_PROVISION_REQUEST, move to SENDING.
+ *   3. Timeout in AWAITING → return to IDLE.
+ *   4. EVENT_PROVISION_SUCCESS / EVENT_PROVISION_FAILED → show feedback,
+ *      return to IDLE.
+ *
+ * The operator_uuid and role_id are read from Kconfig at build time and
+ * embedded in every ProvisionCredentialRequest.
+ *
+ * SHA-256 is computed via mbedTLS (already present for TLS). The raw
+ * credential UID bytes never leave the device — only the hash is sent.
+ */
+
+#include "provisioning_fsm.h"
+#include "event_bus.h"
+#include "error_codes.h"
+#include "credential_types.h"
+#include "sdkconfig.h"
+
+#ifdef CONFIG_PORTUNUS_ENABLE_WIFI
+#include "wifi_mgr.h"
+#endif
+
+#include "mbedtls/sha256.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/queue.h"
+
+#include <string.h>
+#include <inttypes.h>
+
+static const char *TAG = "prov_fsm";
+
+/* ── Task configuration ───────────────────────────────────────────────────── */
+
+static const int FSM_TASK_STACK      = 4096;
+static const int FSM_TASK_PRIORITY   = 5;
+static const int POLL_TASK_STACK     = 4096;
+static const int POLL_TASK_PRIORITY  = 4;
+static const int FSM_EVENT_QUEUE_LEN = 8;
+static const int FSM_POLL_INTERVAL_MS = 100;
+
+/* Credential poll timing — same cadence as the access module. */
+static const int MFRC522_POLL_INTERVAL_MS = 250;
+static const int CARD_REREAD_DELAY_MS     = 1000;
+
+/* ── Helpers ──────────────────────────────────────────────────────────────── */
+
+static inline int64_t now_ms(void)
+{
+    return esp_timer_get_time() / 1000;
+}
+
+/**
+ * @brief Compute SHA-256(data, len) into out[32].
+ * @return true on success.
+ */
+static bool sha256(const uint8_t *data, size_t len, uint8_t out[32])
+{
+    mbedtls_sha256_context ctx;
+    mbedtls_sha256_init(&ctx);
+    int rc = mbedtls_sha256_starts(&ctx, 0 /* is_224=false */);
+    if (rc == 0) { rc = mbedtls_sha256_update(&ctx, data, len); }
+    if (rc == 0) { rc = mbedtls_sha256_finish(&ctx, out); }
+    mbedtls_sha256_free(&ctx);
+    return (rc == 0);
+}
+
+/* ── Constructor ──────────────────────────────────────────────────────────── */
+
+ProvisioningFSM::ProvisioningFSM(ICredentialReader *reader, IFeedback *feedback)
+    : m_reader(reader)
+    , m_feedback(feedback)
+{
+}
+
+/* ── init() ───────────────────────────────────────────────────────────────── */
+
+portunus_err_t ProvisioningFSM::init()
+{
+    ESP_LOGI(TAG, "Initialising provisioning FSM");
+
+    if (m_reader != nullptr) {
+        portunus_err_t err = m_reader->init();
+        if (err == PORTUNUS_OK) {
+            m_has_reader = true;
+            ESP_LOGI(TAG, "Credential reader: OK");
+        } else {
+            ESP_LOGE(TAG, "Credential reader init failed (0x%" PRIx32 ") — cannot provision",
+                     (uint32_t)err);
+            /* Reader is mandatory for a provisioning console. */
+            return err;
+        }
+    } else {
+        ESP_LOGE(TAG, "Credential reader not present — provisioning console requires a reader");
+        return PORTUNUS_FAIL;
+    }
+
+    if (m_feedback != nullptr) {
+        portunus_err_t err = m_feedback->init();
+        if (err == PORTUNUS_OK) {
+            m_has_feedback = true;
+            ESP_LOGI(TAG, "Feedback: OK");
+        } else {
+            m_has_feedback = false;
+            ESP_LOGW(TAG, "Feedback init failed (0x%" PRIx32 ") — LED disabled", (uint32_t)err);
+        }
+    } else {
+        m_has_feedback = false;
+        ESP_LOGW(TAG, "Feedback: not present");
+    }
+
+#ifdef CONFIG_PORTUNUS_ENABLE_WIFI
+    m_has_network = wifi_mgr_is_connected();
+#endif
+
+    m_event_queue = xQueueCreate(FSM_EVENT_QUEUE_LEN, sizeof(portunus_event_t));
+    if (m_event_queue == nullptr) {
+        ESP_LOGE(TAG, "Failed to create FSM event queue");
+        return PORTUNUS_ERR_QUEUE_CREATE;
+    }
+
+    ESP_LOGI(TAG, "Capabilities: reader=%d feedback=%d network=%d",
+             m_has_reader, m_has_feedback, m_has_network);
+
+    return PORTUNUS_OK;
+}
+
+/* ── start() ──────────────────────────────────────────────────────────────── */
+
+portunus_err_t ProvisioningFSM::start()
+{
+    ESP_LOGI(TAG, "Starting provisioning FSM");
+
+    event_bus_subscribe(EVENT_CREDENTIAL_READ,   on_event_bus_event, this);
+    event_bus_subscribe(EVENT_PROVISION_SUCCESS, on_event_bus_event, this);
+    event_bus_subscribe(EVENT_PROVISION_FAILED,  on_event_bus_event, this);
+
+    BaseType_t ret = xTaskCreate(
+        fsm_task_entry,
+        "prov_fsm",
+        FSM_TASK_STACK,
+        this,
+        FSM_TASK_PRIORITY,
+        &m_fsm_task_handle
+    );
+    if (ret != pdPASS) {
+        ESP_LOGE(TAG, "Failed to create FSM task");
+        return PORTUNUS_ERR_TASK_CREATE;
+    }
+
+    ret = xTaskCreate(
+        credential_poll_task_entry,
+        "prov_poll",
+        POLL_TASK_STACK,
+        this,
+        POLL_TASK_PRIORITY,
+        &m_poll_task_handle
+    );
+    if (ret != pdPASS) {
+        ESP_LOGE(TAG, "Failed to create credential polling task");
+        return PORTUNUS_ERR_TASK_CREATE;
+    }
+
+    if (m_has_feedback) {
+        m_feedback->indicate(feedback_type_t::PROVISIONING_IDLE);
+    }
+
+    ESP_LOGI(TAG, "Provisioning FSM running — state=IDLE");
+    ESP_LOGI(TAG, "Operator UUID: %s  Role: %s  Timeout: %d ms",
+             CONFIG_PORTUNUS_OPERATOR_UUID,
+             CONFIG_PORTUNUS_DEFAULT_ROLE_ID,
+             CONFIG_PORTUNUS_PROVISION_TIMEOUT_MS);
+
+    return PORTUNUS_OK;
+}
+
+/* ── Event bus bridge ─────────────────────────────────────────────────────── */
+
+void ProvisioningFSM::on_event_bus_event(const portunus_event_t *event, void *ctx)
+{
+    auto *fsm = static_cast<ProvisioningFSM *>(ctx);
+    if (fsm->m_event_queue == nullptr) { return; }
+
+    if (xQueueSend(fsm->m_event_queue, event, pdMS_TO_TICKS(10)) != pdTRUE) {
+        ESP_LOGW(TAG, "FSM event queue full — dropped event 0x%04x", event->id);
+    }
+}
+
+/* ── Task entry points ────────────────────────────────────────────────────── */
+
+void ProvisioningFSM::fsm_task_entry(void *arg)
+{
+    static_cast<ProvisioningFSM *>(arg)->run();
+}
+
+void ProvisioningFSM::credential_poll_task_entry(void *arg)
+{
+    static_cast<ProvisioningFSM *>(arg)->poll_credential();
+}
+
+/* ── FSM main loop ────────────────────────────────────────────────────────── */
+
+void ProvisioningFSM::run()
+{
+    portunus_event_t event;
+    const TickType_t poll_timeout = pdMS_TO_TICKS(FSM_POLL_INTERVAL_MS);
+
+    for (;;) {
+        if (xQueueReceive(m_event_queue, &event, poll_timeout) == pdTRUE) {
+            process_event(event);
+        }
+
+        /* Check both the awaiting timeout and the deferred idle re-arm. */
+        if (m_timeout_deadline_ms != 0 && now_ms() >= m_timeout_deadline_ms) {
+            handle_timeout();
+        }
+
+#ifdef CONFIG_PORTUNUS_ENABLE_WIFI
+        m_has_network = wifi_mgr_is_connected();
+#endif
+    }
+}
+
+/* ── Event processing ─────────────────────────────────────────────────────── */
+
+void ProvisioningFSM::process_event(const portunus_event_t &event)
+{
+    switch (event.id) {
+    case EVENT_CREDENTIAL_READ:
+        handle_credential_read(&event.payload.credential_read);
+        break;
+
+    case EVENT_PROVISION_SUCCESS:
+    case EVENT_PROVISION_FAILED:
+        handle_provision_result(&event.payload.provision_result);
+        break;
+
+    default:
+        break;
+    }
+}
+
+void ProvisioningFSM::handle_credential_read(const event_credential_read_t *cred)
+{
+    char uid_str[CREDENTIAL_UID_HEX_STR_LEN];
+    credential_uid_to_hex(&cred->credential, uid_str, sizeof(uid_str));
+
+    switch (m_prov_state) {
+
+    case PROV_STATE_IDLE:
+        /* Scan 1: operator presence confirmed. Start timeout. */
+        ESP_LOGI(TAG, "Scan 1 (operator) — UID: %s — awaiting new credential", uid_str);
+        m_prov_state          = PROV_STATE_AWAITING_CREDENTIAL;
+        m_timeout_deadline_ms = now_ms() + CONFIG_PORTUNUS_PROVISION_TIMEOUT_MS;
+        if (m_has_feedback) {
+            m_feedback->indicate(feedback_type_t::PROVISIONING_AWAITING);
+        }
+        break;
+
+    case PROV_STATE_AWAITING_CREDENTIAL: {
+        /* Scan 2: new credential. Compute SHA-256 and publish request. */
+        ESP_LOGI(TAG, "Scan 2 (new credential) — UID: %s — sending provision request", uid_str);
+
+        uint8_t hash[32];
+        if (!sha256(cred->credential.uid, cred->credential.uid_len, hash)) {
+            ESP_LOGE(TAG, "SHA-256 computation failed — aborting provisioning");
+            transition_to_idle();
+            return;
+        }
+
+        if (!m_has_network) {
+            ESP_LOGW(TAG, "Network unavailable — cannot provision");
+            transition_to_idle();
+            return;
+        }
+
+        portunus_event_t req_evt;
+        memset(&req_evt, 0, sizeof(req_evt));
+        req_evt.id = EVENT_PROVISION_REQUEST;
+
+        strncpy(req_evt.payload.provision_request.operator_uuid,
+                CONFIG_PORTUNUS_OPERATOR_UUID,
+                sizeof(req_evt.payload.provision_request.operator_uuid) - 1);
+
+        memcpy(req_evt.payload.provision_request.credential_hash, hash, 32);
+
+        strncpy(req_evt.payload.provision_request.role_id,
+                CONFIG_PORTUNUS_DEFAULT_ROLE_ID,
+                sizeof(req_evt.payload.provision_request.role_id) - 1);
+
+        event_bus_publish(&req_evt);
+
+        m_prov_state = PROV_STATE_SENDING;
+        if (m_has_feedback) {
+            m_feedback->indicate(feedback_type_t::CARD_READ);
+        }
+        break;
+    }
+
+    case PROV_STATE_SENDING:
+        /* Ignore credential reads while waiting for server response. */
+        ESP_LOGD(TAG, "Credential read ignored — provisioning in progress");
+        break;
+    }
+}
+
+void ProvisioningFSM::handle_provision_result(const event_provision_result_t *result)
+{
+    if (m_prov_state != PROV_STATE_SENDING) {
+        return;
+    }
+
+    switch (result->reason) {
+    case PROVISION_RESULT_SUCCESS:
+        ESP_LOGI(TAG, "Provisioning SUCCESS — member_uuid=%s", result->member_uuid);
+        if (m_has_feedback) {
+            m_feedback->indicate(feedback_type_t::PROVISIONING_SUCCESS);
+        }
+        break;
+
+    case PROVISION_RESULT_DUPLICATE_ACTIVE:
+    case PROVISION_RESULT_DUPLICATE_INACTIVE:
+    case PROVISION_RESULT_DUPLICATE_PENDING:
+        ESP_LOGW(TAG, "Provisioning DUPLICATE — detail=%s", result->detail);
+        if (m_has_feedback) {
+            m_feedback->indicate(feedback_type_t::PROVISIONING_DUPLICATE);
+        }
+        break;
+
+    case PROVISION_RESULT_UNAUTHORIZED:
+        ESP_LOGW(TAG, "Provisioning UNAUTHORIZED — detail=%s", result->detail);
+        if (m_has_feedback) {
+            m_feedback->indicate(feedback_type_t::PROVISIONING_UNAUTHORIZED);
+        }
+        break;
+
+    case PROVISION_RESULT_INVALID_ROLE:
+        ESP_LOGE(TAG, "Provisioning INVALID_ROLE — check PORTUNUS_DEFAULT_ROLE_ID");
+        if (m_has_feedback) {
+            m_feedback->indicate(feedback_type_t::PROVISIONING_UNAUTHORIZED);
+        }
+        break;
+
+    default:
+        ESP_LOGE(TAG, "Provisioning comm error — detail=%s", result->detail);
+        if (m_has_feedback) {
+            m_feedback->indicate(feedback_type_t::SYSTEM_ERROR);
+        }
+        break;
+    }
+
+    /*
+     * Return to IDLE after a brief delay so the one-shot feedback
+     * patterns have time to complete before the idle pattern resumes.
+     * The FSM main loop will call transition_to_idle() after the
+     * queue drains; we set state now so no further scan 2s are accepted.
+     */
+    m_prov_state = PROV_STATE_IDLE;
+
+    /* Re-arm idle feedback after one-shot pattern duration (~1.5 s). */
+    m_timeout_deadline_ms = now_ms() + 1500;
+}
+
+void ProvisioningFSM::handle_timeout()
+{
+    if (m_prov_state == PROV_STATE_AWAITING_CREDENTIAL) {
+        ESP_LOGW(TAG, "Provisioning timeout — returning to IDLE");
+        transition_to_idle();
+        return;
+    }
+
+    /* Used as a deferred re-arm for idle feedback after result patterns. */
+    if (m_prov_state == PROV_STATE_IDLE && m_timeout_deadline_ms != 0 &&
+        now_ms() >= m_timeout_deadline_ms) {
+        m_timeout_deadline_ms = 0;
+        if (m_has_feedback) {
+            m_feedback->indicate(feedback_type_t::PROVISIONING_IDLE);
+        }
+    }
+}
+
+void ProvisioningFSM::transition_to_idle()
+{
+    m_prov_state          = PROV_STATE_IDLE;
+    m_timeout_deadline_ms = 0;
+    if (m_has_feedback) {
+        m_feedback->indicate(feedback_type_t::PROVISIONING_IDLE);
+    }
+    ESP_LOGI(TAG, "FSM → IDLE");
+}
+
+/* ── Credential polling sub-task ──────────────────────────────────────────── */
+
+void ProvisioningFSM::poll_credential()
+{
+    const TickType_t poll_interval = pdMS_TO_TICKS(MFRC522_POLL_INTERVAL_MS);
+    const TickType_t reread_delay  = pdMS_TO_TICKS(CARD_REREAD_DELAY_MS);
+
+    for (;;) {
+        credential_t cred;
+        portunus_err_t err = m_reader->read(&cred);
+
+        if (err == PORTUNUS_OK) {
+            portunus_event_t event;
+            memset(&event, 0, sizeof(event));
+            event.id = EVENT_CREDENTIAL_READ;
+            event.payload.credential_read.credential   = cred;
+            event.payload.credential_read.timestamp_ms =
+                esp_timer_get_time() / 1000;
+
+            event_bus_publish(&event);
+
+            m_reader->halt();
+            vTaskDelay(reread_delay);
+            continue;
+        }
+
+        vTaskDelay(poll_interval);
+    }
+}

--- a/access_module/drivers/feedback_led/src/feedback_led.cpp
+++ b/access_module/drivers/feedback_led/src/feedback_led.cpp
@@ -42,6 +42,30 @@ static const int READY_CYCLE_TICKS = 60;
 /* SYSTEM_ERROR: rapid blink 200ms on/off = 4 ticks on + 4 ticks off */
 static const int ERROR_HALF_CYCLE_TICKS = 4;
 
+/* PROVISIONING_IDLE: double-blink every 4 s (distinguishable from SYSTEM_READY) */
+static const int PROV_IDLE_ON_TICKS    = 1;   /* 50ms pulse */
+static const int PROV_IDLE_GAP_TICKS   = 3;   /* 150ms gap between pulses */
+static const int PROV_IDLE_CYCLE_TICKS = 80;  /* 4 s total period */
+
+/* PROVISIONING_AWAITING: slow 50/50 pulse (1 s on / 1 s off) */
+static const int PROV_AWAIT_HALF_TICKS = 20;
+
+/* PROVISIONING_SUCCESS: 5× rapid blinks (one-shot) */
+static const int PROV_SUCCESS_ON    = 2;
+static const int PROV_SUCCESS_OFF   = 2;
+static const int PROV_SUCCESS_COUNT = 5;
+
+/* PROVISIONING_DUPLICATE: 2× medium blinks (one-shot) */
+static const int PROV_DUP_ON    = 4;
+static const int PROV_DUP_OFF   = 4;
+static const int PROV_DUP_COUNT = 2;
+
+/* PROVISIONING_UNAUTHORIZED: 500ms solid on + 3× rapid blinks (one-shot) */
+static const int PROV_UNAUTH_LONG_ON     = 10; /* 500ms */
+static const int PROV_UNAUTH_RAPID_ON    = 2;
+static const int PROV_UNAUTH_RAPID_OFF   = 2;
+static const int PROV_UNAUTH_RAPID_COUNT = 3;
+
 /* ── Task configuration ───────────────────────────────────────────────────── */
 
 static const int PATTERN_TASK_STACK = 2048;
@@ -177,6 +201,82 @@ void FeedbackLed::run_patterns()
                 led_on();
             }
             break;
+
+        case feedback_type_t::PROVISIONING_IDLE: {
+            /* Double-blink every 4 s: pulse–gap–pulse–long-off */
+            int pos = tick % PROV_IDLE_CYCLE_TICKS;
+            int second_pulse_start = PROV_IDLE_ON_TICKS + PROV_IDLE_GAP_TICKS;
+            if (pos == 0 || pos == second_pulse_start) {
+                led_on();
+            } else if (pos == PROV_IDLE_ON_TICKS ||
+                       pos == second_pulse_start + PROV_IDLE_ON_TICKS) {
+                led_off();
+            }
+            break;
+        }
+
+        case feedback_type_t::PROVISIONING_AWAITING: {
+            /* 1 s on / 1 s off slow pulse */
+            int pos = tick % (PROV_AWAIT_HALF_TICKS * 2);
+            if (pos == 0) {
+                led_on();
+            } else if (pos == PROV_AWAIT_HALF_TICKS) {
+                led_off();
+            }
+            break;
+        }
+
+        case feedback_type_t::PROVISIONING_SUCCESS: {
+            /* 5× rapid blinks then off (one-shot) */
+            int cycle = PROV_SUCCESS_ON + PROV_SUCCESS_OFF;
+            int total = cycle * PROV_SUCCESS_COUNT;
+            if (tick < total) {
+                int pos = tick % cycle;
+                if (pos == 0) led_on();
+                else if (pos == PROV_SUCCESS_ON) led_off();
+            } else {
+                led_off();
+                current = feedback_type_t::NONE;
+            }
+            break;
+        }
+
+        case feedback_type_t::PROVISIONING_DUPLICATE: {
+            /* 2× medium blinks then off (one-shot) */
+            int cycle = PROV_DUP_ON + PROV_DUP_OFF;
+            int total = cycle * PROV_DUP_COUNT;
+            if (tick < total) {
+                int pos = tick % cycle;
+                if (pos == 0) led_on();
+                else if (pos == PROV_DUP_ON) led_off();
+            } else {
+                led_off();
+                current = feedback_type_t::NONE;
+            }
+            break;
+        }
+
+        case feedback_type_t::PROVISIONING_UNAUTHORIZED: {
+            /* 500ms solid on, then 3× rapid blinks, then off (one-shot) */
+            if (tick == 0) {
+                led_on();
+            } else if (tick == PROV_UNAUTH_LONG_ON) {
+                led_off();
+            } else if (tick > PROV_UNAUTH_LONG_ON) {
+                int pos_in_rapid = tick - PROV_UNAUTH_LONG_ON;
+                int cycle  = PROV_UNAUTH_RAPID_ON + PROV_UNAUTH_RAPID_OFF;
+                int total  = cycle * PROV_UNAUTH_RAPID_COUNT;
+                if (pos_in_rapid < total) {
+                    int pos = pos_in_rapid % cycle;
+                    if (pos == 0) led_on();
+                    else if (pos == PROV_UNAUTH_RAPID_ON) led_off();
+                } else {
+                    led_off();
+                    current = feedback_type_t::NONE;
+                }
+            }
+            break;
+        }
         }
 
         tick++;

--- a/access_module/main/Kconfig.projbuild
+++ b/access_module/main/Kconfig.projbuild
@@ -1,5 +1,58 @@
 menu "Portunus Configuration"
 
+    menu "Module Variant"
+        choice PORTUNUS_MODULE_TYPE
+            prompt "Firmware variant"
+            default PORTUNUS_MODULE_TYPE_ACCESS_POINT
+            help
+                Select the firmware variant built into this module.
+
+                ACCESS_POINT: Standard door-control module. Reads credentials,
+                checks them against the server, and controls a door strike.
+
+                PROVISIONING_CONSOLE: Two-scan credential enrollment console.
+                An operator scan followed by a new credential scan sends a
+                ProvisionCredentialRequest to the server. No door-strike
+                hardware required.
+
+            config PORTUNUS_MODULE_TYPE_ACCESS_POINT
+                bool "Access point (door control)"
+
+            config PORTUNUS_MODULE_TYPE_PROVISIONING_CONSOLE
+                bool "Provisioning console (credential enrollment)"
+        endchoice
+
+        menu "Provisioning Console Settings"
+            depends on PORTUNUS_MODULE_TYPE_PROVISIONING_CONSOLE
+
+            config PORTUNUS_PROVISION_TIMEOUT_MS
+                int "Awaiting-credential timeout (milliseconds)"
+                default 30000
+                range 5000 120000
+                help
+                    How long the console waits for the new credential after
+                    the operator scan before returning to idle and requiring
+                    the operator to scan again.
+
+            config PORTUNUS_OPERATOR_UUID
+                string "Operator UUID"
+                default ""
+                help
+                    UUID of the member_access record authorised to use this
+                    provisioning console. Must match a record that has the
+                    credential.provision_guest permission assigned on the server.
+                    Generate with: uuidgen
+
+            config PORTUNUS_DEFAULT_ROLE_ID
+                string "Default role ID for provisioned members"
+                default "guest"
+                help
+                    role_id sent in every ProvisionCredentialRequest. Must
+                    match an existing role on the Portunus server.
+                    Common values: "guest", "member".
+        endmenu
+    endmenu
+
     menu "Feature Toggles"
         config PORTUNUS_ENABLE_MFRC522
             bool "Enable MFRC522 RFID reader"

--- a/access_module/main/main.cpp
+++ b/access_module/main/main.cpp
@@ -23,7 +23,12 @@
 #include "system_states.h"
 #include "timing_config.h"
 #include "event_bus.h"
+#ifdef CONFIG_PORTUNUS_MODULE_TYPE_ACCESS_POINT
 #include "system_fsm.h"
+#endif
+#ifdef CONFIG_PORTUNUS_MODULE_TYPE_PROVISIONING_CONSOLE
+#include "provisioning_fsm.h"
+#endif
 
 /* Optional services (feature-gated) */
 #ifdef CONFIG_PORTUNUS_ENABLE_HEARTBEAT
@@ -156,7 +161,16 @@ extern "C" void app_main(void)
 #endif
 
     /* ── 5. Construct and initialise FSM ─────────────────────────────────── */
+
+#ifdef CONFIG_PORTUNUS_MODULE_TYPE_ACCESS_POINT
     static SystemFSM fsm(reader_ptr, access_ptr, feedback_ptr);
+    ESP_LOGI(TAG, "Variant: ACCESS_POINT");
+#else
+    /* Provisioning console: no door-strike hardware needed. */
+    (void)access_ptr;
+    static ProvisioningFSM fsm(reader_ptr, feedback_ptr);
+    ESP_LOGI(TAG, "Variant: PROVISIONING_CONSOLE");
+#endif
 
     if (fsm.init() != PORTUNUS_OK) {
         ESP_LOGE(TAG, "System halted: FSM init failure");

--- a/access_module/services/server_comm/src/server_comm.cpp
+++ b/access_module/services/server_comm/src/server_comm.cpp
@@ -27,6 +27,11 @@
 #include <pb_encode.h>
 #include <pb_decode.h>
 
+/* Provisioning: SHA-256 via mbedTLS (always available when mbedtls is linked) */
+#ifdef CONFIG_PORTUNUS_MODULE_TYPE_PROVISIONING_CONSOLE
+  #include "mbedtls/sha256.h"
+#endif
+
 /* TLS / HMAC */
 #if PORTUNUS_USE_TLS
   #if PORTUNUS_TLS_USE_CUSTOM_CA
@@ -89,6 +94,9 @@ static int s_idle_ticks = 0;
 /* Reusable URL buffers built once at init */
 static char s_heartbeat_url[URL_MAX_LEN];
 static char s_access_url[URL_MAX_LEN];
+#ifdef CONFIG_PORTUNUS_MODULE_TYPE_PROVISIONING_CONSOLE
+static char s_provision_url[URL_MAX_LEN];
+#endif
 #endif /* !PORTUNUS_USE_GRPC */
 
 /* ── HMAC helper ───────────────────────────────────────────────────────────── */
@@ -134,7 +142,12 @@ static bool compute_hmac_hex(const uint8_t *data, size_t data_len,
 /* ── Forward declarations ──────────────────────────────────────────────────── */
 static void comm_task(void *arg);
 static void handle_heartbeat(const event_heartbeat_t *hb);
+#ifdef CONFIG_PORTUNUS_MODULE_TYPE_ACCESS_POINT
 static void handle_credential(const event_credential_read_t *cred);
+#endif
+#ifdef CONFIG_PORTUNUS_MODULE_TYPE_PROVISIONING_CONSOLE
+static void handle_provision(const event_provision_request_t *req);
+#endif
 
 /* ── Helpers ───────────────────────────────────────────────────────────────── */
 
@@ -347,6 +360,15 @@ static void on_credential_event(const portunus_event_t *event, void *ctx)
     xQueueSend(s_comm_queue, event, 0);
 }
 
+#ifdef CONFIG_PORTUNUS_MODULE_TYPE_PROVISIONING_CONSOLE
+static void on_provision_event(const portunus_event_t *event, void *ctx)
+{
+    (void)ctx;
+    if (s_comm_queue == NULL) { return; }
+    xQueueSend(s_comm_queue, event, 0);
+}
+#endif
+
 /* ── Event handlers (run on comm_task) ─────────────────────────────────────── */
 
 /**
@@ -538,6 +560,133 @@ static void handle_credential(const event_credential_read_t *cred)
     event_bus_publish(&decision);
 }
 
+/* ── Provisioning handler (PROVISIONING_CONSOLE only) ──────────────────────── */
+
+#ifdef CONFIG_PORTUNUS_MODULE_TYPE_PROVISIONING_CONSOLE
+
+static void publish_provision_result(provision_result_reason_t reason,
+                                     const char *member_uuid,
+                                     const char *detail)
+{
+    portunus_event_t evt;
+    memset(&evt, 0, sizeof(evt));
+    evt.id = (reason == PROVISION_RESULT_SUCCESS)
+             ? EVENT_PROVISION_SUCCESS
+             : EVENT_PROVISION_FAILED;
+
+    if (member_uuid) {
+        strncpy(evt.payload.provision_result.member_uuid, member_uuid,
+                sizeof(evt.payload.provision_result.member_uuid) - 1);
+    }
+    evt.payload.provision_result.reason = reason;
+    if (detail) {
+        strncpy(evt.payload.provision_result.detail, detail,
+                sizeof(evt.payload.provision_result.detail) - 1);
+    }
+    event_bus_publish(&evt);
+}
+
+static void handle_provision(const event_provision_request_t *req)
+{
+    /* Build ProvisionCredentialRequest */
+    portunus_v1_ProvisionCredentialRequest pb_req =
+        portunus_v1_ProvisionCredentialRequest_init_zero;
+
+    strncpy(pb_req.operator_uuid, req->operator_uuid,
+            sizeof(pb_req.operator_uuid) - 1);
+    strncpy(pb_req.module_id, PORTUNUS_MODULE_ID,
+            sizeof(pb_req.module_id) - 1);
+    strncpy(pb_req.role_id, req->role_id,
+            sizeof(pb_req.role_id) - 1);
+
+    pb_req.credential_hash.size = 32;
+    memcpy(pb_req.credential_hash.bytes, req->credential_hash, 32);
+
+    /* Encode */
+    uint8_t req_buf[portunus_v1_ProvisionCredentialRequest_size];
+    pb_ostream_t ostream = pb_ostream_from_buffer(req_buf, sizeof(req_buf));
+    if (!pb_encode(&ostream, portunus_v1_ProvisionCredentialRequest_fields, &pb_req)) {
+        ESP_LOGE(TAG, "Provision encode failed: %s", PB_GET_ERROR(&ostream));
+        publish_provision_result(PROVISION_RESULT_COMM_ERROR, NULL, "encode_error");
+        return;
+    }
+
+    /* Send */
+    uint8_t resp_buf[portunus_v1_ProvisionCredentialResponse_size + 16];
+    int resp_len = 0;
+
+#if PORTUNUS_USE_GRPC
+    int grpc_status = 0;
+    portunus_err_t err = grpc_post_proto(
+        "/portunus.v1.PortunusService/ProvisionCredential",
+        req_buf, ostream.bytes_written,
+        resp_buf, sizeof(resp_buf),
+        &resp_len, &grpc_status);
+    if (err != PORTUNUS_OK) {
+        ESP_LOGW(TAG, "Provision gRPC failed: 0x%04x", (unsigned)err);
+        publish_provision_result(PROVISION_RESULT_COMM_ERROR, NULL, "grpc_error");
+        return;
+    }
+    if (grpc_status != GRPC_STATUS_OK) {
+        ESP_LOGW(TAG, "Provision gRPC status: %d", grpc_status);
+        publish_provision_result(PROVISION_RESULT_COMM_ERROR, NULL, "grpc_status_error");
+        return;
+    }
+#else
+    int http_status = 0;
+    portunus_err_t err = http_post_proto(s_provision_url,
+                                         req_buf, ostream.bytes_written,
+                                         resp_buf, sizeof(resp_buf),
+                                         &resp_len, &http_status);
+    if (err != PORTUNUS_OK) {
+        ESP_LOGW(TAG, "Provision HTTP failed: 0x%04x", (unsigned)err);
+        publish_provision_result(PROVISION_RESULT_COMM_ERROR, NULL, "http_error");
+        return;
+    }
+    if (http_status != 200) {
+        ESP_LOGW(TAG, "Provision server returned HTTP %d", http_status);
+        publish_provision_result(PROVISION_RESULT_COMM_ERROR, NULL, "http_status_error");
+        return;
+    }
+#endif
+
+    /* Decode response */
+    portunus_v1_ProvisionCredentialResponse pb_resp =
+        portunus_v1_ProvisionCredentialResponse_init_zero;
+    pb_istream_t istream = pb_istream_from_buffer(resp_buf, (size_t)resp_len);
+    if (!pb_decode(&istream, portunus_v1_ProvisionCredentialResponse_fields, &pb_resp)) {
+        ESP_LOGW(TAG, "Provision decode failed: %s", PB_GET_ERROR(&istream));
+        publish_provision_result(PROVISION_RESULT_COMM_ERROR, NULL, "decode_error");
+        return;
+    }
+
+    ESP_LOGI(TAG, "Provision response — status=%d member_uuid=%s detail=%s",
+             pb_resp.status, pb_resp.member_uuid, pb_resp.detail);
+
+    /* Map proto status → internal reason code */
+    provision_result_reason_t reason;
+    switch (pb_resp.status) {
+    case portunus_v1_ProvisionStatus_PROVISION_STATUS_SUCCESS:
+        reason = PROVISION_RESULT_SUCCESS;           break;
+    case portunus_v1_ProvisionStatus_PROVISION_STATUS_DUPLICATE_ACTIVE:
+        reason = PROVISION_RESULT_DUPLICATE_ACTIVE;  break;
+    case portunus_v1_ProvisionStatus_PROVISION_STATUS_DUPLICATE_INACTIVE:
+        reason = PROVISION_RESULT_DUPLICATE_INACTIVE; break;
+    case portunus_v1_ProvisionStatus_PROVISION_STATUS_DUPLICATE_PENDING:
+        reason = PROVISION_RESULT_DUPLICATE_PENDING; break;
+    case portunus_v1_ProvisionStatus_PROVISION_STATUS_UNAUTHORIZED:
+        reason = PROVISION_RESULT_UNAUTHORIZED;      break;
+    case portunus_v1_ProvisionStatus_PROVISION_STATUS_INVALID_ROLE:
+        reason = PROVISION_RESULT_INVALID_ROLE;      break;
+    default:
+        reason = PROVISION_RESULT_COMM_ERROR;        break;
+    }
+
+    publish_provision_result(reason, pb_resp.member_uuid, pb_resp.detail);
+}
+
+#endif /* CONFIG_PORTUNUS_MODULE_TYPE_PROVISIONING_CONSOLE */
+
 /* ── Task ──────────────────────────────────────────────────────────────────── */
 
 static void comm_task(void *arg)
@@ -586,9 +735,16 @@ static void comm_task(void *arg)
         case EVENT_HEARTBEAT:
             handle_heartbeat(&event.payload.heartbeat);
             break;
+#ifdef CONFIG_PORTUNUS_MODULE_TYPE_ACCESS_POINT
         case EVENT_CREDENTIAL_READ:
             handle_credential(&event.payload.credential_read);
             break;
+#endif
+#ifdef CONFIG_PORTUNUS_MODULE_TYPE_PROVISIONING_CONSOLE
+        case EVENT_PROVISION_REQUEST:
+            handle_provision(&event.payload.provision_request);
+            break;
+#endif
         default:
             ESP_LOGW(TAG, "Unexpected event 0x%04x in comm queue",
                      (unsigned)event.id);
@@ -639,6 +795,11 @@ portunus_err_t server_comm_init(void)
     snprintf(s_access_url, sizeof(s_access_url),
              "https://%s:%d/v1/access_request",
              PORTUNUS_SERVER_HOST, PORTUNUS_TLS_SERVER_PORT);
+    #ifdef CONFIG_PORTUNUS_MODULE_TYPE_PROVISIONING_CONSOLE
+    snprintf(s_provision_url, sizeof(s_provision_url),
+             "https://%s:%d/v1/provision_credential",
+             PORTUNUS_SERVER_HOST, PORTUNUS_TLS_SERVER_PORT);
+    #endif
   #else
     snprintf(s_heartbeat_url, sizeof(s_heartbeat_url),
              "http://%s:%d/v1/heartbeat",
@@ -646,11 +807,20 @@ portunus_err_t server_comm_init(void)
     snprintf(s_access_url, sizeof(s_access_url),
              "http://%s:%d/v1/access_request",
              PORTUNUS_SERVER_HOST, PORTUNUS_SERVER_PORT);
+    #ifdef CONFIG_PORTUNUS_MODULE_TYPE_PROVISIONING_CONSOLE
+    snprintf(s_provision_url, sizeof(s_provision_url),
+             "http://%s:%d/v1/provision_credential",
+             PORTUNUS_SERVER_HOST, PORTUNUS_SERVER_PORT);
+    #endif
   #endif
 
     ESP_LOGI(TAG, "Transport: HTTP/1.1");
     ESP_LOGI(TAG, "Heartbeat URL: %s", s_heartbeat_url);
+    #ifdef CONFIG_PORTUNUS_MODULE_TYPE_ACCESS_POINT
     ESP_LOGI(TAG, "Access URL:    %s", s_access_url);
+    #else
+    ESP_LOGI(TAG, "Provision URL: %s", s_provision_url);
+    #endif
 #endif /* PORTUNUS_USE_GRPC */
 
     /* Create internal queue */
@@ -668,10 +838,18 @@ portunus_err_t server_comm_init(void)
         ESP_LOGE(TAG, "Failed to subscribe to heartbeat events: 0x%04x", (unsigned)sub_err);
     }
 
+#ifdef CONFIG_PORTUNUS_MODULE_TYPE_ACCESS_POINT
     sub_err = event_bus_subscribe(EVENT_CREDENTIAL_READ, on_credential_event, NULL);
     if (sub_err != PORTUNUS_OK) {
         ESP_LOGE(TAG, "Failed to subscribe to credential events: 0x%04x", (unsigned)sub_err);
     }
+#endif
+#ifdef CONFIG_PORTUNUS_MODULE_TYPE_PROVISIONING_CONSOLE
+    sub_err = event_bus_subscribe(EVENT_PROVISION_REQUEST, on_provision_event, NULL);
+    if (sub_err != PORTUNUS_OK) {
+        ESP_LOGE(TAG, "Failed to subscribe to provision events: 0x%04x", (unsigned)sub_err);
+    }
+#endif
 
     /* Start task */
     BaseType_t ret = xTaskCreate(


### PR DESCRIPTION
<h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">New files</h3><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><a href="vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/core/provisioning_fsm/include/provisioning_fsm.h" target="_blank" rel="noopener noreferrer" style="color: rgb(55, 148, 255);">provisioning_fsm.h</a><span> </span>— two-scan FSM class definition</li><li><a href="vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/core/provisioning_fsm/src/provisioning_fsm.cpp" target="_blank" rel="noopener noreferrer" style="color: rgb(55, 148, 255);">provisioning_fsm.cpp</a><span> </span>— full FSM implementation with SHA-256 hashing via mbedTLS</li><li><a href="vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/core/provisioning_fsm/CMakeLists.txt" target="_blank" rel="noopener noreferrer" style="color: rgb(55, 148, 255);">provisioning_fsm/CMakeLists.txt</a></li></ul><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Modified files</h3>
File | What changed
-- | --
Kconfig.projbuild | PORTUNUS_MODULE_TYPE choice (ACCESS_POINT / PROVISIONING_CONSOLE) + PROVISION_TIMEOUT_MS, OPERATOR_UUID, DEFAULT_ROLE_ID
event_types.h | EVENT_PROVISION_REQUEST/SUCCESS/FAILED + payload structs + provision_result_reason_t enum
i_feedback.h | 5 new feedback_type_t values for provisioning states
feedback_led.cpp | LED patterns for all 5 provisioning states (double-heartbeat, slow pulse, 5× rapid, 2× medium, long+rapid)
server_comm.cpp | Conditionally subscribes to EVENT_CREDENTIAL_READ (access point) or EVENT_PROVISION_REQUEST (provisioning); handle_provision() encodes + sends the gRPC/HTTP call and maps all response status codes
main.cpp | Forks on CONFIG_PORTUNUS_MODULE_TYPE_* to instantiate SystemFSM or ProvisioningFSM

<h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Key design decisions</h3><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><strong><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">operator_uuid</code><span> </span>via Kconfig</strong><span> </span>— the provisioning console is a trusted device; the operator UUID is burned in at build time and sent in every<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ProvisionCredentialRequest</code>.</li><li><strong>SHA-256 on-device</strong><span> </span>— computed by the FSM using the mbedTLS context API over<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">credential.uid[uid_len]</code><span> </span>before the event is published. The raw credential never leaves the device.</li><li><strong>server_comm never subscribes to both paths</strong><span> </span>— at any given build, it handles either<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">EVENT_CREDENTIAL_READ</code><span> </span>(access check) or<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">EVENT_PROVISION_REQUEST</code><span> </span>(provisioning), not both.</li><li><strong>Heartbeat is shared</strong><span> </span>— the provisioning console still sends heartbeats via the existing<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">heartbeat_service</code><span> </span>path unchanged.</li></ul>New files
[provisioning_fsm.h](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/core/provisioning_fsm/include/provisioning_fsm.h) — two-scan FSM class definition
[provisioning_fsm.cpp](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/core/provisioning_fsm/src/provisioning_fsm.cpp) — full FSM implementation with SHA-256 hashing via mbedTLS
[provisioning_fsm/CMakeLists.txt](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/core/provisioning_fsm/CMakeLists.txt)
Modified files
File	What changed
[Kconfig.projbuild](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/main/Kconfig.projbuild)	PORTUNUS_MODULE_TYPE choice (ACCESS_POINT / PROVISIONING_CONSOLE) + PROVISION_TIMEOUT_MS, OPERATOR_UUID, DEFAULT_ROLE_ID
[event_types.h](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/components/portunus_types/include/event_types.h)	EVENT_PROVISION_REQUEST/SUCCESS/FAILED + payload structs + provision_result_reason_t enum
[i_feedback.h](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/components/portunus_interfaces/include/i_feedback.h)	5 new feedback_type_t values for provisioning states
[feedback_led.cpp](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/drivers/feedback_led/src/feedback_led.cpp)	LED patterns for all 5 provisioning states (double-heartbeat, slow pulse, 5× rapid, 2× medium, long+rapid)
[server_comm.cpp](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/services/server_comm/src/server_comm.cpp)	Conditionally subscribes to EVENT_CREDENTIAL_READ (access point) or EVENT_PROVISION_REQUEST (provisioning); handle_provision() encodes + sends the gRPC/HTTP call and maps all response status codes
[main.cpp](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/main/main.cpp)	Forks on CONFIG_PORTUNUS_MODULE_TYPE_* to instantiate SystemFSM or ProvisioningFSM
Key design decisions
operator_uuid via Kconfig — the provisioning console is a trusted device; the operator UUID is burned in at build time and sent in every ProvisionCredentialRequest.
SHA-256 on-device — computed by the FSM using the mbedTLS context API over credential.uid[uid_len] before the event is published. The raw credential never leaves the device.
server_comm never subscribes to both paths — at any given build, it handles either EVENT_CREDENTIAL_READ (access check) or EVENT_PROVISION_REQUEST (provisioning), not both.
Heartbeat is shared — the provisioning console still sends heartbeats via the existing heartbeat_service path unchanged.<h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">New files</h3><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><a href="vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/core/provisioning_fsm/include/provisioning_fsm.h" target="_blank" rel="noopener noreferrer" style="color: rgb(55, 148, 255);">provisioning_fsm.h</a><span> </span>— two-scan FSM class definition</li><li><a href="vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/core/provisioning_fsm/src/provisioning_fsm.cpp" target="_blank" rel="noopener noreferrer" style="color: rgb(55, 148, 255);">provisioning_fsm.cpp</a><span> </span>— full FSM implementation with SHA-256 hashing via mbedTLS</li><li><a href="vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/core/provisioning_fsm/CMakeLists.txt" target="_blank" rel="noopener noreferrer" style="color: rgb(55, 148, 255);">provisioning_fsm/CMakeLists.txt</a></li></ul><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Modified files</h3>
File | What changed
-- | --
Kconfig.projbuild | PORTUNUS_MODULE_TYPE choice (ACCESS_POINT / PROVISIONING_CONSOLE) + PROVISION_TIMEOUT_MS, OPERATOR_UUID, DEFAULT_ROLE_ID
event_types.h | EVENT_PROVISION_REQUEST/SUCCESS/FAILED + payload structs + provision_result_reason_t enum
i_feedback.h | 5 new feedback_type_t values for provisioning states
feedback_led.cpp | LED patterns for all 5 provisioning states (double-heartbeat, slow pulse, 5× rapid, 2× medium, long+rapid)
server_comm.cpp | Conditionally subscribes to EVENT_CREDENTIAL_READ (access point) or EVENT_PROVISION_REQUEST (provisioning); handle_provision() encodes + sends the gRPC/HTTP call and maps all response status codes
main.cpp | Forks on CONFIG_PORTUNUS_MODULE_TYPE_* to instantiate SystemFSM or ProvisioningFSM

<h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Key design decisions</h3><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><strong><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">operator_uuid</code><span> </span>via Kconfig</strong><span> </span>— the provisioning console is a trusted device; the operator UUID is burned in at build time and sent in every<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ProvisionCredentialRequest</code>.</li><li><strong>SHA-256 on-device</strong><span> </span>— computed by the FSM using the mbedTLS context API over<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">credential.uid[uid_len]</code><span> </span>before the event is published. The raw credential never leaves the device.</li><li><strong>server_comm never subscribes to both paths</strong><span> </span>— at any given build, it handles either<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">EVENT_CREDENTIAL_READ</code><span> </span>(access check) or<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">EVENT_PROVISION_REQUEST</code><span> </span>(provisioning), not both.</li><li><strong>Heartbeat is shared</strong><span> </span>— the provisioning console still sends heartbeats via the existing<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">heartbeat_service</code><span> </span>path unchanged.</li></ul>New files
[provisioning_fsm.h](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/core/provisioning_fsm/include/provisioning_fsm.h) — two-scan FSM class definition
[provisioning_fsm.cpp](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/core/provisioning_fsm/src/provisioning_fsm.cpp) — full FSM implementation with SHA-256 hashing via mbedTLS
[provisioning_fsm/CMakeLists.txt](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/core/provisioning_fsm/CMakeLists.txt)
Modified files
File	What changed
[Kconfig.projbuild](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/main/Kconfig.projbuild)	PORTUNUS_MODULE_TYPE choice (ACCESS_POINT / PROVISIONING_CONSOLE) + PROVISION_TIMEOUT_MS, OPERATOR_UUID, DEFAULT_ROLE_ID
[event_types.h](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/components/portunus_types/include/event_types.h)	EVENT_PROVISION_REQUEST/SUCCESS/FAILED + payload structs + provision_result_reason_t enum
[i_feedback.h](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/components/portunus_interfaces/include/i_feedback.h)	5 new feedback_type_t values for provisioning states
[feedback_led.cpp](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/drivers/feedback_led/src/feedback_led.cpp)	LED patterns for all 5 provisioning states (double-heartbeat, slow pulse, 5× rapid, 2× medium, long+rapid)
[server_comm.cpp](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/services/server_comm/src/server_comm.cpp)	Conditionally subscribes to EVENT_CREDENTIAL_READ (access point) or EVENT_PROVISION_REQUEST (provisioning); handle_provision() encodes + sends the gRPC/HTTP call and maps all response status codes
[main.cpp](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/main/main.cpp)	Forks on CONFIG_PORTUNUS_MODULE_TYPE_* to instantiate SystemFSM or ProvisioningFSM
Key design decisions
operator_uuid via Kconfig — the provisioning console is a trusted device; the operator UUID is burned in at build time and sent in every ProvisionCredentialRequest.
SHA-256 on-device — computed by the FSM using the mbedTLS context API over credential.uid[uid_len] before the event is published. The raw credential never leaves the device.
server_comm never subscribes to both paths — at any given build, it handles either EVENT_CREDENTIAL_READ (access check) or EVENT_PROVISION_REQUEST (provisioning), not both.
Heartbeat is shared — the provisioning console still sends heartbeats via the existing heartbeat_service path unchanged.