### PR TITLE
implement POST /v1/provision_credential for PROVISIONING_CONSOLE variant

### DIFF
--- a/server/cmd/portunus-server/main.go
+++ b/server/cmd/portunus-server/main.go
@@ -116,6 +116,9 @@ func main() {
 	expiryWorker.Start(ctx)
 	defer expiryWorker.Stop()
 
+	// Provisioning service: handles device-initiated provisioning from PROVISIONING_CONSOLE modules.
+	provisionSvc := service.NewProvisionService(registry, memberAccessStore, roleStore, adminUserStore)
+
 	// Admin service for module/credential/door management via REST API.
 	adminSvc := service.NewAdminService(moduleAdminStore, credentialStore, credentialHashSecret)
 
@@ -137,6 +140,7 @@ func main() {
 		Addr:                cfg.HTTPAddr,
 		HeartbeatService:    heartbeatSvc,
 		AccessService:       accessSvc,
+		ProvisionService:    provisionSvc,
 		AdminService:        adminSvc,
 		AuthService:         authSvc,
 		AdminUserService:    adminUserSvc,
@@ -211,6 +215,7 @@ func main() {
 			Logger:           logger,
 			HeartbeatService: heartbeatSvc,
 			AccessService:    accessSvc,
+			ProvisionService: provisionSvc,
 		})
 		pb.RegisterPortunusServiceServer(grpcServer, grpcHandler)
 		reflection.Register(grpcServer)

--- a/server/internal/grpcapi/server.go
+++ b/server/internal/grpcapi/server.go
@@ -30,6 +30,7 @@ type Dependencies struct {
 	Logger           *log.Logger
 	HeartbeatService *service.HeartbeatService
 	AccessService    *service.AccessService
+	ProvisionService *service.ProvisionService
 }
 
 // Server implements pb.PortunusServiceServer.
@@ -39,6 +40,7 @@ type Server struct {
 	logger           *log.Logger
 	heartbeatService *service.HeartbeatService
 	accessService    *service.AccessService
+	provisionService *service.ProvisionService
 }
 
 // NewServer creates a gRPC server handler that delegates to the service layer.
@@ -47,6 +49,7 @@ func NewServer(d Dependencies) *Server {
 		logger:           d.Logger,
 		heartbeatService: d.HeartbeatService,
 		accessService:    d.AccessService,
+		provisionService: d.ProvisionService,
 	}
 }
 
@@ -126,4 +129,57 @@ func (s *Server) RequestAccess(ctx context.Context, req *pb.AccessRequest) (*pb.
 		ModuleId:   resp.ModuleID,
 		ServerTime: resp.ServerTime,
 	}, nil
+}
+
+// ─── Provision ──────────────────────────────────────────────────────────────
+
+func (s *Server) ProvisionCredential(ctx context.Context, req *pb.ProvisionCredentialRequest) (*pb.ProvisionCredentialResponse, error) {
+	domainReq := types.ProvisionCredentialRequest{
+		OperatorUUID:   req.GetOperatorUuid(),
+		ModuleID:       req.GetModuleId(),
+		CredentialHash: req.GetCredentialHash(),
+		RoleID:         req.GetRoleId(),
+	}
+
+	resp, err := s.provisionService.Provision(ctx, domainReq)
+	if err != nil {
+		switch {
+		case errors.Is(err, service.ErrInvalidModuleID):
+			return nil, status.Errorf(codes.InvalidArgument, "invalid module_id: %v", err)
+		case errors.Is(err, service.ErrProvisionCredentialHashRequired):
+			return nil, status.Errorf(codes.InvalidArgument, "invalid credential_hash: %v", err)
+		default:
+			s.logger.Printf("provision_credential gRPC error: %v", err)
+			return nil, status.Errorf(codes.Internal, "unexpected server error")
+		}
+	}
+
+	if !resp.Known {
+		return nil, status.Errorf(codes.NotFound, "unknown module")
+	}
+
+	return &pb.ProvisionCredentialResponse{
+		MemberUuid: resp.MemberUUID,
+		Status:     domainProvisionStatusToProto(resp.Status),
+		Detail:     resp.Detail,
+	}, nil
+}
+
+func domainProvisionStatusToProto(s types.ProvisionStatus) pb.ProvisionStatus {
+	switch s {
+	case types.ProvisionStatusSuccess:
+		return pb.ProvisionStatus_PROVISION_STATUS_SUCCESS
+	case types.ProvisionStatusDuplicateActive:
+		return pb.ProvisionStatus_PROVISION_STATUS_DUPLICATE_ACTIVE
+	case types.ProvisionStatusDuplicateInactive:
+		return pb.ProvisionStatus_PROVISION_STATUS_DUPLICATE_INACTIVE
+	case types.ProvisionStatusDuplicatePending:
+		return pb.ProvisionStatus_PROVISION_STATUS_DUPLICATE_PENDING
+	case types.ProvisionStatusUnauthorized:
+		return pb.ProvisionStatus_PROVISION_STATUS_UNAUTHORIZED
+	case types.ProvisionStatusInvalidRole:
+		return pb.ProvisionStatus_PROVISION_STATUS_INVALID_ROLE
+	default:
+		return pb.ProvisionStatus_PROVISION_STATUS_UNSPECIFIED
+	}
 }

--- a/server/internal/httpapi/convert.go
+++ b/server/internal/httpapi/convert.go
@@ -65,3 +65,41 @@ func accessResponseToProto(r types.AccessResponse) *pb.AccessResponse {
 		ServerTime: r.ServerTime,
 	}
 }
+
+// ── Provision ────────────────────────────────────────────────────────────────
+
+func provisionRequestFromProto(p *pb.ProvisionCredentialRequest) types.ProvisionCredentialRequest {
+	return types.ProvisionCredentialRequest{
+		OperatorUUID:   p.GetOperatorUuid(),
+		ModuleID:       p.GetModuleId(),
+		CredentialHash: p.GetCredentialHash(),
+		RoleID:         p.GetRoleId(),
+	}
+}
+
+func provisionResponseToProto(r types.ProvisionCredentialResponse) *pb.ProvisionCredentialResponse {
+	return &pb.ProvisionCredentialResponse{
+		MemberUuid: r.MemberUUID,
+		Status:     domainProvisionStatusToProto(r.Status),
+		Detail:     r.Detail,
+	}
+}
+
+func domainProvisionStatusToProto(s types.ProvisionStatus) pb.ProvisionStatus {
+	switch s {
+	case types.ProvisionStatusSuccess:
+		return pb.ProvisionStatus_PROVISION_STATUS_SUCCESS
+	case types.ProvisionStatusDuplicateActive:
+		return pb.ProvisionStatus_PROVISION_STATUS_DUPLICATE_ACTIVE
+	case types.ProvisionStatusDuplicateInactive:
+		return pb.ProvisionStatus_PROVISION_STATUS_DUPLICATE_INACTIVE
+	case types.ProvisionStatusDuplicatePending:
+		return pb.ProvisionStatus_PROVISION_STATUS_DUPLICATE_PENDING
+	case types.ProvisionStatusUnauthorized:
+		return pb.ProvisionStatus_PROVISION_STATUS_UNAUTHORIZED
+	case types.ProvisionStatusInvalidRole:
+		return pb.ProvisionStatus_PROVISION_STATUS_INVALID_ROLE
+	default:
+		return pb.ProvisionStatus_PROVISION_STATUS_UNSPECIFIED
+	}
+}

--- a/server/internal/httpapi/server.go
+++ b/server/internal/httpapi/server.go
@@ -19,6 +19,7 @@ type Dependencies struct {
 	Addr                string
 	HeartbeatService    *service.HeartbeatService
 	AccessService       *service.AccessService
+	ProvisionService    *service.ProvisionService
 	AdminService        *service.AdminService
 	AuthService         *service.AuthService
 	AdminUserService    *service.AdminUserService
@@ -38,6 +39,7 @@ type Server struct {
 	mux                 *http.ServeMux
 	heartbeatService    *service.HeartbeatService
 	accessService       *service.AccessService
+	provisionService    *service.ProvisionService
 	adminService        *service.AdminService
 	authService         *service.AuthService
 	adminUserService    *service.AdminUserService
@@ -55,6 +57,7 @@ func NewServer(d Dependencies) *Server {
 		mux:                 mux,
 		heartbeatService:    d.HeartbeatService,
 		accessService:       d.AccessService,
+		provisionService:    d.ProvisionService,
 		adminService:        d.AdminService,
 		authService:         d.AuthService,
 		adminUserService:    d.AdminUserService,
@@ -67,6 +70,9 @@ func NewServer(d Dependencies) *Server {
 	// ── Device endpoints (ESP32 modules) ────────────────────────────────
 	mux.HandleFunc("POST /v1/heartbeat", s.handleHeartbeat)
 	mux.HandleFunc("POST /v1/access_request", s.handleAccessRequest)
+	if d.ProvisionService != nil {
+		mux.HandleFunc("POST /v1/provision_credential", s.handleProvisionCredential)
+	}
 
 	// ── Admin auth endpoints (no permission guard — open to any caller) ─
 	if d.AuthService != nil {
@@ -298,6 +304,55 @@ func (s *Server) handleAccessRequest(w http.ResponseWriter, r *http.Request) {
 
 	if protoReq {
 		writeProto(w, http.StatusOK, accessResponseToProto(resp))
+	} else {
+		writeJSON(w, http.StatusOK, resp)
+	}
+}
+
+func (s *Server) handleProvisionCredential(w http.ResponseWriter, r *http.Request) {
+	var req types.ProvisionCredentialRequest
+	protoReq := isProtobuf(r)
+
+	if protoReq {
+		var pbReq pb.ProvisionCredentialRequest
+		if err := readProto(r, &pbReq); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_proto", "invalid protobuf body")
+			return
+		}
+		req = provisionRequestFromProto(&pbReq)
+	} else {
+		r.Body = http.MaxBytesReader(w, r.Body, maxRequestBody)
+		dec := json.NewDecoder(r.Body)
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_json", "invalid JSON body")
+			return
+		}
+	}
+
+	resp, err := s.provisionService.Provision(r.Context(), req)
+	if err != nil {
+		switch {
+		case errors.Is(err, service.ErrInvalidModuleID):
+			writeError(w, http.StatusBadRequest, "invalid_module_id", err.Error())
+			return
+		case errors.Is(err, service.ErrProvisionCredentialHashRequired):
+			writeError(w, http.StatusBadRequest, "invalid_credential_hash", err.Error())
+			return
+		default:
+			s.logger.Printf("provision_credential error: %v", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "unexpected server error")
+			return
+		}
+	}
+
+	if !resp.Known {
+		writeError(w, http.StatusForbidden, "unknown_module", "module is not registered")
+		return
+	}
+
+	if protoReq {
+		writeProto(w, http.StatusOK, provisionResponseToProto(resp))
 	} else {
 		writeJSON(w, http.StatusOK, resp)
 	}

--- a/server/internal/portunus/service/provision_service.go
+++ b/server/internal/portunus/service/provision_service.go
@@ -1,0 +1,179 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/store"
+	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/types"
+)
+
+var ErrProvisionCredentialHashRequired = errors.New("credential_hash is required")
+
+// ProvisionService handles device-initiated member provisioning from the
+// PROVISIONING_CONSOLE firmware variant.  It creates a fully active member
+// record in a single flow — no pending_authorization step.
+type ProvisionService struct {
+	registry    *DeviceRegistry
+	memberStore store.MemberAccessStore
+	roleStore   store.RoleStore
+	adminUsers  store.AdminUserStore
+}
+
+func NewProvisionService(
+	registry *DeviceRegistry,
+	memberStore store.MemberAccessStore,
+	roleStore store.RoleStore,
+	adminUsers store.AdminUserStore,
+) *ProvisionService {
+	return &ProvisionService{
+		registry:    registry,
+		memberStore: memberStore,
+		roleStore:   roleStore,
+		adminUsers:  adminUsers,
+	}
+}
+
+// Provision handles a ProvisionCredentialRequest from a PROVISIONING_CONSOLE module.
+// It returns a domain error only for internal failures; all provisioning outcomes
+// (duplicate, unauthorized, invalid_role) are encoded in the response Status.
+func (s *ProvisionService) Provision(
+	ctx context.Context,
+	req types.ProvisionCredentialRequest,
+) (types.ProvisionCredentialResponse, error) {
+	moduleID := strings.TrimSpace(req.ModuleID)
+	operatorUUID := strings.TrimSpace(req.OperatorUUID)
+	roleID := strings.TrimSpace(req.RoleID)
+
+	if moduleID == "" {
+		return types.ProvisionCredentialResponse{}, ErrInvalidModuleID
+	}
+	if len(req.CredentialHash) == 0 {
+		return types.ProvisionCredentialResponse{}, ErrProvisionCredentialHashRequired
+	}
+
+	// Check module is known.
+	known, err := s.registry.IsKnown(ctx, moduleID)
+	if err != nil {
+		return types.ProvisionCredentialResponse{}, err
+	}
+	_ = s.registry.NoteSeen(ctx, moduleID, known)
+
+	if !known {
+		return types.ProvisionCredentialResponse{OK: false, Known: false}, nil
+	}
+
+	// Verify operator: must be an enabled admin user.
+	if operatorUUID == "" {
+		return types.ProvisionCredentialResponse{
+			OK:     true,
+			Known:  true,
+			Status: types.ProvisionStatusUnauthorized,
+			Detail: "operator_uuid is required",
+		}, nil
+	}
+	operator, err := s.adminUsers.GetAdminUserByUUID(ctx, operatorUUID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return types.ProvisionCredentialResponse{
+				OK:     true,
+				Known:  true,
+				Status: types.ProvisionStatusUnauthorized,
+				Detail: "operator not found",
+			}, nil
+		}
+		return types.ProvisionCredentialResponse{}, fmt.Errorf("operator lookup: %w", err)
+	}
+	if !operator.Enabled {
+		return types.ProvisionCredentialResponse{
+			OK:     true,
+			Known:  true,
+			Status: types.ProvisionStatusUnauthorized,
+			Detail: "operator account is disabled",
+		}, nil
+	}
+
+	// Validate role.
+	if roleID == "" {
+		return types.ProvisionCredentialResponse{
+			OK:     true,
+			Known:  true,
+			Status: types.ProvisionStatusInvalidRole,
+			Detail: "role_id is required",
+		}, nil
+	}
+	if _, err := s.roleStore.GetRole(ctx, roleID); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return types.ProvisionCredentialResponse{
+				OK:     true,
+				Known:  true,
+				Status: types.ProvisionStatusInvalidRole,
+				Detail: fmt.Sprintf("role %q not found", roleID),
+			}, nil
+		}
+		return types.ProvisionCredentialResponse{}, fmt.Errorf("role lookup: %w", err)
+	}
+
+	// Check credential uniqueness before attempting to create the member.
+	existing, err := s.memberStore.GetMemberByCredential(ctx, req.CredentialHash)
+	if err != nil && !errors.Is(err, store.ErrNotFound) {
+		return types.ProvisionCredentialResponse{}, fmt.Errorf("credential lookup: %w", err)
+	}
+	if err == nil {
+		dupStatus, dupDetail := provisionDuplicateStatus(existing)
+		return types.ProvisionCredentialResponse{
+			OK:     true,
+			Known:  true,
+			Status: dupStatus,
+			Detail: dupDetail,
+		}, nil
+	}
+
+	// Create member and attach credential. Using ProvisioningStatusActive skips
+	// the pending_authorization workflow used in admin-initiated flows.
+	memberUUID := uuid.New().String()
+	if err := s.memberStore.CreateMember(
+		ctx, memberUUID, roleID, operatorUUID,
+		store.ProvisioningStatusActive, nil, nil,
+	); err != nil {
+		return types.ProvisionCredentialResponse{}, fmt.Errorf("create member: %w", err)
+	}
+	if err := s.memberStore.AttachCredential(ctx, memberUUID, req.CredentialHash); err != nil {
+		if errors.Is(err, store.ErrMemberCredentialConflict) {
+			return types.ProvisionCredentialResponse{
+				OK:     true,
+				Known:  true,
+				Status: types.ProvisionStatusDuplicateActive,
+				Detail: "credential assigned between check and insert",
+			}, nil
+		}
+		return types.ProvisionCredentialResponse{}, fmt.Errorf("attach credential: %w", err)
+	}
+
+	return types.ProvisionCredentialResponse{
+		OK:         true,
+		Known:      true,
+		MemberUUID: memberUUID,
+		Status:     types.ProvisionStatusSuccess,
+	}, nil
+}
+
+// provisionDuplicateStatus maps an existing member record to the appropriate
+// ProvisionStatus and a human-readable detail string.
+func provisionDuplicateStatus(m *store.MemberAccessRecord) (types.ProvisionStatus, string) {
+	switch m.Status {
+	case store.MemberStatusActive:
+		if m.ProvisioningStatus == store.ProvisioningStatusPendingAuthorization {
+			return types.ProvisionStatusDuplicatePending, "credential already attached to a pending member"
+		}
+		return types.ProvisionStatusDuplicateActive, "credential already assigned to an active member"
+	case store.MemberStatusExpired, store.MemberStatusArchived:
+		return types.ProvisionStatusDuplicateInactive, "credential already assigned to an expired or archived member"
+	default:
+		return types.ProvisionStatusDuplicateActive, "credential already assigned to another member"
+	}
+}

--- a/server/internal/portunus/types/provision.go
+++ b/server/internal/portunus/types/provision.go
@@ -1,0 +1,32 @@
+package types
+
+// ProvisionCredentialRequest is the domain type for device-initiated provisioning.
+// The credential_hash carries the SHA-256 digest computed on-device via mbedTLS;
+// the raw UID bytes never leave the device.
+type ProvisionCredentialRequest struct {
+	OperatorUUID   string `json:"operator_uuid"`
+	ModuleID       string `json:"module_id"`
+	CredentialHash []byte `json:"credential_hash"` // 32-byte SHA-256, pre-computed on device
+	RoleID         string `json:"role_id"`
+}
+
+// ProvisionStatus represents the outcome of a device-initiated provisioning request.
+type ProvisionStatus string
+
+const (
+	ProvisionStatusSuccess           ProvisionStatus = "success"
+	ProvisionStatusDuplicateActive   ProvisionStatus = "duplicate_active"
+	ProvisionStatusDuplicateInactive ProvisionStatus = "duplicate_inactive"
+	ProvisionStatusDuplicatePending  ProvisionStatus = "duplicate_pending"
+	ProvisionStatusUnauthorized      ProvisionStatus = "unauthorized"
+	ProvisionStatusInvalidRole       ProvisionStatus = "invalid_role"
+)
+
+// ProvisionCredentialResponse is the domain response for device-initiated provisioning.
+type ProvisionCredentialResponse struct {
+	OK         bool            `json:"ok"`
+	Known      bool            `json:"known"`
+	MemberUUID string          `json:"member_uuid,omitempty"`
+	Status     ProvisionStatus `json:"status,omitempty"`
+	Detail     string          `json:"detail,omitempty"`
+}


### PR DESCRIPTION
Adds the server-side handler for the two-scan provisioning flow introduced in the PROVISIONING_CONSOLE firmware variant (PR 7).

- types/provision.go: domain request/response types and ProvisionStatus enum
- service/provision_service.go: ProvisionService validates operator (admin user lookup), module, role, and credential uniqueness before creating an immediately-active member record with the device-computed SHA-256 hash
- httpapi/convert.go: proto↔domain converters for provision messages
- httpapi/server.go: POST /v1/provision_credential (protobuf + JSON)
- grpcapi/server.go: ProvisionCredential RPC implementation
- main.go: wires ProvisionService into both HTTP and gRPC servers