### PR TITLE
Feature clean update and polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 **LAN-first door access control system** — ESP32 access modules communicate with a Go server to manage RFID-based door access for makerspaces, workshops, and small offices.
 
+Named after the Roman god of keys and doors.
+
 ---
 
 ## How it works
 
 ```
- ┌────────────────┐                               ┌──────────────────────┐
+ ┌────────────────┐                               ┌─────────────────────┐
  │  Credential    │                               │  Admin Web UI / curl │
  │  tap           │                               │                      │
  └───────┬────────┘                               └──────────┬───────────┘

--- a/access_module/README.md
+++ b/access_module/README.md
@@ -474,4 +474,4 @@ To keep expectations aligned with the actual code in this snapshot:
 - `../docs/api.md` — server API details
 - `../docs/setup_firmware.md` — deeper firmware setup guidance
 - `drivers/README.md` — driver naming and extension patterns
-- `../docs/shared_secrets_setup.md` — TLS certificate setup, HMAC shared secret, and credential hash secret configuration
+- `shared_secrets_setup.md` — additional setup context for shared secrets and local certificates

--- a/access_module/shared_secrets_setup.md
+++ b/access_module/shared_secrets_setup.md
@@ -1,0 +1,476 @@
+# Portunus Access Module — TLS and Shared Secret Setup
+
+This guide explains how the current Portunus snapshot secures communication
+between the ESP32 access module and the Go server.
+
+For the access module, there are **two active security layers** you can
+configure today:
+
+1. **TLS server authentication and transport encryption**
+   - The access module can talk to the server over HTTPS.
+   - For LAN deployments, the recommended model is a **private CA** whose CA
+     certificate is embedded in the firmware and used to validate the
+     server certificate.
+   - For publicly trusted certificates, the firmware can use the ESP-IDF
+     certificate bundle instead.
+
+2. **HMAC-SHA256 request signing**
+   - The module signs each outbound protobuf payload with a pre-shared secret.
+   - The server verifies the `X-Portunus-Sig` header before accepting the
+     request.
+
+These protections apply to the current HTTP/protobuf path and to the optional
+**gRPC over HTTP/2 + TLS** path. The transport changes, but the trust material
+is the same:
+
+- **TLS** protects the channel.
+- **HMAC** authenticates the request body.
+
+## What this document covers
+
+This file focuses only on the security material shared between the firmware and
+server:
+
+- generating and installing TLS certificates for the current repo workflow
+- embedding a private CA certificate into the firmware for LAN use
+- generating and configuring the HMAC shared secret
+- current Kconfig settings that control TLS, CA pinning, HMAC, and optional
+  gRPC transport
+
+This file does **not** cover:
+
+- secure boot
+- flash encryption
+- per-device hardware secret storage
+- production provisioning infrastructure
+
+Those are important hardening topics, but they are **not implemented as a full
+repo workflow in this snapshot**.
+
+---
+
+## 1. Current secure deployment model
+
+For the current project, the recommended secure LAN setup is:
+
+1. Generate a **private CA** and a **server certificate** using the repo script.
+2. Start the server with that certificate and key.
+3. Embed the generated **CA certificate** into the firmware.
+4. Enable **TLS** and **HMAC** in the firmware.
+5. Set the same HMAC secret on the server.
+6. Build and flash the module.
+
+That results in:
+
+- encrypted traffic
+- server certificate validation on the ESP32
+- signed request bodies
+- compatibility with both:
+  - HTTP/1.1 + protobuf device endpoints
+  - optional gRPC over HTTP/2 + TLS
+
+---
+
+## 2. TLS setup
+
+### 2.1 Recommended approach for the current repo
+
+For a typical Portunus LAN deployment, use the repo-provided certificate
+script:
+
+```bash
+task certs:generate -- --ip 192.168.1.100
+```
+
+You can also add a local DNS name:
+
+```bash
+task certs:generate -- --ip 192.168.1.100 --dns portunus.local
+```
+
+This uses `scripts/generate_certs.sh`, which:
+
+- creates a private CA certificate and key under `certs/`
+- creates a server certificate and key under `certs/`
+- signs the server certificate with the private CA
+- copies the CA certificate into the firmware tree at:
+
+```text
+access_module/certs/ca_cert.pem
+```
+
+If `access_module/certs/` does not exist yet, the script creates it.
+
+### 2.2 Output files
+
+After running the script, the repo contains:
+
+```text
+certs/ca.key
+certs/ca.pem
+certs/server.key
+certs/server.csr
+certs/server.pem
+access_module/certs/ca_cert.pem
+```
+
+Meaning:
+
+- `ca.key` — private CA key, keep secret
+- `ca.pem` — private CA certificate
+- `server.key` — server private key, keep secret
+- `server.pem` — server certificate used by the Go server
+- `access_module/certs/ca_cert.pem` — firmware copy of the CA certificate
+
+Do **not** commit private keys.
+
+### 2.3 Server environment for TLS
+
+Start the server with the generated certificate and key:
+
+```bash
+export PORTUNUS_HTTP_ADDR=:8443
+export PORTUNUS_TLS_CERT_FILE="$PWD/certs/server.pem"
+export PORTUNUS_TLS_KEY_FILE="$PWD/certs/server.key"
+```
+
+Then run the server normally.
+
+If you also want the optional gRPC listener, set a gRPC address too:
+
+```bash
+export PORTUNUS_GRPC_ADDR=:50051
+```
+
+The current server uses the **same TLS certificate and key** for both:
+
+- HTTPS device/admin traffic
+- optional gRPC traffic
+
+### 2.4 Current firmware TLS options
+
+Open firmware configuration:
+
+```bash
+cd access_module
+idf.py menuconfig
+```
+
+Navigate to:
+
+```text
+Portunus Configuration
+  Security Configuration
+```
+
+Relevant current options are:
+
+| Option | Purpose | Recommended value for LAN deployment |
+|---|---|---|
+| `CONFIG_PORTUNUS_USE_TLS` | Enables HTTPS/TLS | `y` |
+| `CONFIG_PORTUNUS_TLS_SERVER_PORT` | HTTPS port | `8443` |
+| `CONFIG_PORTUNUS_TLS_SKIP_VERIFY` | Disables certificate validation | `n` |
+| `CONFIG_PORTUNUS_TLS_USE_CUSTOM_CA` | Pins to `access_module/certs/ca_cert.pem` | `y` |
+
+For LAN deployments using the repo-generated CA, the correct secure setup is:
+
+- TLS enabled
+- skip verify disabled
+- custom CA enabled
+
+### 2.5 Public CA certificates
+
+The firmware can also validate a publicly trusted server certificate using the
+ESP-IDF certificate bundle.
+
+For that case:
+
+- keep `CONFIG_PORTUNUS_USE_TLS=y`
+- set `CONFIG_PORTUNUS_TLS_SKIP_VERIFY=n`
+- set `CONFIG_PORTUNUS_TLS_USE_CUSTOM_CA=n`
+
+That tells the firmware to use the built-in CA bundle instead of
+`access_module/certs/ca_cert.pem`.
+
+### 2.6 Development-only skip verify mode
+
+`CONFIG_PORTUNUS_TLS_SKIP_VERIFY=y` exists in the current firmware, but it is
+strictly a development-only escape hatch.
+
+When enabled, the module does **not** properly validate the server certificate.
+That is useful only for temporary testing with mismatched or self-signed certs
+that are not pinned correctly.
+
+Do not use this mode for any real deployment.
+
+---
+
+## 3. HMAC shared secret setup
+
+### 3.1 What the HMAC secret does
+
+When HMAC is enabled, the firmware computes:
+
+```text
+HMAC-SHA256(secret, raw_protobuf_body)
+```
+
+and sends the resulting hex digest in:
+
+```text
+X-Portunus-Sig
+```
+
+The server verifies the same signature before it processes the message.
+
+In the current codebase:
+
+- the HTTP path signs the raw protobuf request body
+- the gRPC path also signs the raw protobuf message body and sends the
+  signature as metadata
+
+This means the same HMAC secret works for both transports.
+
+### 3.2 Generate a secret
+
+Generate a 32-byte hex secret:
+
+```bash
+openssl rand -hex 32
+```
+
+Example format:
+
+```text
+9e56d5a0d7a9f4d0d1d57e2a89f65e4db4f5e3324a0c1c8a28d9c4d1c57e8f92
+```
+
+Generate your own value. Do not reuse example strings.
+
+### 3.3 Server environment for HMAC
+
+Set the server secret:
+
+```bash
+export PORTUNUS_HMAC_SECRET="<your-64-char-hex-secret>"
+```
+
+When this environment variable is set, the current server enables HMAC
+verification for inbound POSTs and for gRPC requests if gRPC is enabled.
+
+### 3.4 Firmware HMAC options
+
+In `menuconfig`, navigate to:
+
+```text
+Portunus Configuration
+  Security Configuration
+```
+
+Relevant current options are:
+
+| Option | Purpose | Recommended value |
+|---|---|---|
+| `CONFIG_PORTUNUS_HMAC_ENABLED` | Enables HMAC request signing | `y` |
+| `CONFIG_PORTUNUS_HMAC_SECRET` | Shared secret | same value as server |
+
+The secret configured in firmware must exactly match:
+
+```text
+PORTUNUS_HMAC_SECRET
+```
+
+on the server.
+
+### 3.5 Storage caveat
+
+In the current snapshot, `CONFIG_PORTUNUS_HMAC_SECRET` is compiled into the
+firmware image and stored in flash.
+
+That means:
+
+- firmware binaries should be treated as sensitive
+- `sdkconfig` should not be committed with real secrets in it
+- the current repo does **not** provide a finished secure provisioning flow for
+  injecting secrets per device at manufacturing time
+
+---
+
+## 4. Current network and transport settings that must match
+
+Besides TLS and HMAC, the module still needs the correct server location.
+
+Under:
+
+```text
+Portunus Configuration
+  Network Configuration
+```
+
+set:
+
+| Option | Purpose | Example |
+|---|---|---|
+| `CONFIG_PORTUNUS_SERVER_HOST` | Server IP or hostname | `192.168.1.100` |
+| `CONFIG_PORTUNUS_SERVER_PORT` | HTTP port when TLS is disabled | `8080` |
+| `CONFIG_PORTUNUS_SERVER_REQUEST_TIMEOUT_MS` | request timeout | `5000` |
+
+If TLS is enabled, the module uses `CONFIG_PORTUNUS_TLS_SERVER_PORT` for the
+HTTP/protobuf path.
+
+If gRPC is enabled, also configure under:
+
+```text
+Portunus Configuration
+  Transport Configuration
+```
+
+| Option | Purpose | Example |
+|---|---|---|
+| `CONFIG_PORTUNUS_USE_GRPC` | Use gRPC instead of HTTP/protobuf | `y` or `n` |
+| `CONFIG_PORTUNUS_GRPC_SERVER_PORT` | gRPC server port | `50051` |
+
+Important current behavior:
+
+- `CONFIG_PORTUNUS_USE_GRPC` depends on TLS being enabled
+- the server must expose `PORTUNUS_GRPC_ADDR` when gRPC is enabled in the
+  firmware
+- HTTP and gRPC can coexist on different ports
+
+---
+
+## 5. Current end-to-end secure setup example
+
+### 5.1 Generate certificates
+
+From the repo root:
+
+```bash
+task certs:generate -- --ip 192.168.1.100
+```
+
+### 5.2 Generate an HMAC secret
+
+```bash
+openssl rand -hex 32
+```
+
+Save the output somewhere secure.
+
+### 5.3 Start the server
+
+Example secure LAN configuration:
+
+```bash
+export PORTUNUS_ENV=prod
+export PORTUNUS_DB_PATH=./data/portunus.db
+
+export PORTUNUS_HTTP_ADDR=:8443
+export PORTUNUS_TLS_CERT_FILE="$PWD/certs/server.pem"
+export PORTUNUS_TLS_KEY_FILE="$PWD/certs/server.key"
+
+export PORTUNUS_HMAC_SECRET="<your-64-char-hex-secret>"
+
+# Optional gRPC listener
+export PORTUNUS_GRPC_ADDR=:50051
+```
+
+### 5.4 Configure the firmware
+
+In `idf.py menuconfig`, set at minimum:
+
+```text
+CONFIG_PORTUNUS_USE_TLS=y
+CONFIG_PORTUNUS_TLS_SERVER_PORT=8443
+CONFIG_PORTUNUS_TLS_SKIP_VERIFY=n
+CONFIG_PORTUNUS_TLS_USE_CUSTOM_CA=y
+CONFIG_PORTUNUS_HMAC_ENABLED=y
+CONFIG_PORTUNUS_HMAC_SECRET="<same secret as server>"
+CONFIG_PORTUNUS_SERVER_HOST="192.168.1.100"
+```
+
+If using gRPC, also set:
+
+```text
+CONFIG_PORTUNUS_USE_GRPC=y
+CONFIG_PORTUNUS_GRPC_SERVER_PORT=50051
+```
+
+### 5.5 Build and flash
+
+```bash
+cd access_module
+idf.py build
+idf.py -p /dev/ttyACM0 flash
+idf.py monitor
+```
+
+---
+
+## 6. Certificate and secret rotation
+
+### 6.1 Rotating the HMAC secret
+
+To rotate the HMAC secret in the current implementation:
+
+1. generate a new secret
+2. update `PORTUNUS_HMAC_SECRET` on the server
+3. update `CONFIG_PORTUNUS_HMAC_SECRET` in each module
+4. rebuild and reflash each device
+
+Until a device is reflashed, it will fail HMAC verification.
+
+### 6.2 Rotating the TLS certificate
+
+For the repo’s private-CA model:
+
+- regenerate the certs with `task certs:generate`
+- restart the server with the new `server.pem` and `server.key`
+- reflash firmware only if the CA changed and therefore
+  `access_module/certs/ca_cert.pem` changed
+
+If only the server leaf certificate changes but it is still signed by the same
+CA, the existing firmware CA pin remains valid.
+
+---
+
+## 7. What is and is not true in the current snapshot
+
+### Implemented now
+
+- TLS support in firmware
+- custom CA pinning for LAN deployments
+- fallback to ESP-IDF certificate bundle for public CAs
+- HMAC signing in firmware
+- HMAC verification in the Go server
+- optional gRPC transport using the same trust material
+- certificate generation script in the repo
+
+### Not a finished repo workflow yet
+
+- secure boot enablement workflow
+- flash encryption enablement workflow
+- device-unique secret provisioning
+- hardware-backed key storage on the module
+- production sdkconfig overlay files committed in the repo
+
+The `Taskfile` includes `firmware:build:dev` and `firmware:build:prod`, but the
+expected `sdkconfig.defaults*` overlay files are not present in this snapshot.
+Use `menuconfig` and your local build environment for real security settings.
+
+---
+
+## 8. Practical recommendations
+
+For the current Portunus snapshot, use this baseline:
+
+- `CONFIG_PORTUNUS_USE_TLS=y`
+- `CONFIG_PORTUNUS_TLS_SKIP_VERIFY=n`
+- `CONFIG_PORTUNUS_TLS_USE_CUSTOM_CA=y` for LAN/private CA deployments
+- `CONFIG_PORTUNUS_HMAC_ENABLED=y`
+- a fresh 32-byte HMAC secret generated with OpenSSL
+- repo-generated CA and server cert for LAN use
+- optional gRPC only after confirming `PORTUNUS_GRPC_ADDR` is active on the
+  server
+
+That is the security setup that best matches the current code.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -381,12 +381,12 @@ Both transports encode identical protobuf messages. The server can run both list
 │          │       │ last_seen    │       │ free_heap        │
 └──────────┘       │ last_ip      │       └──────────────────┘
                    │ last_fw_ver  │
-                   │ last_rssi    │        ┌──────────────────┐
-                   └──────┬───────┘        │  access_events   │
-                          │                │                  │
-                          │          *────1│ access_event_id  │
-                          └────────────────│ module_id (FK)   │
-                                           │ door_id (FK)     │
+                   │ last_rssi    │       ┌──────────────────┐
+                   └──────┬───────┘       │  access_events   │
+                          │               │                  │
+                          │         *────1│ access_event_id  │
+                          └───────────────│ module_id (FK)   │
+                                          │ door_id (FK)     │
                    ┌─────────────┐         │ cred_hash(FK)    │
                    │ credentials │   *────1│ decision_granted │
                    │             │─────────│ decision_reason  │
@@ -461,7 +461,7 @@ The HMAC pre-shared key and WiFi credentials are stored in the firmware's flash 
 | Pure-Go SQLite (modernc.org) | No CGo dependency means trivial cross-compilation and no C toolchain required on the deployment target. |
 | Serialized write worker | Eliminates SQLite's "database is locked" without requiring WAL-only or connection pooling complexity. Single goroutine processes all writes sequentially. |
 | Protobuf as wire format | Strongly-typed contract, compact binary encoding (important for ESP32 memory), code generation for both Go and C (Nanopb). |
-| Dual transport (HTTP + gRPC) | HTTP/1.1 is simpler to debug and works with curl. gRPC provides bidirectional streaming for future features. Both share the same protobuf messages. (HTTP/1.1 should never be used in prod) |
+| Dual transport (HTTP + gRPC) | HTTP/1.1 is simpler to debug and works with curl. gRPC provides bidirectional streaming for future features. Both share the same protobuf messages. |
 | HMAC over request body | Application-level authentication independent of TLS. Verifies that the message came from an enrolled device, not just any TLS client. |
 | Keyed HMAC-SHA256 credential hashing | Protects credential UIDs at rest with a server-side secret. Unlike bare SHA-256, keyed hashing prevents offline rainbow-table attacks on a stolen database. Secret set via `PORTUNUS_CREDENTIAL_HASH_SECRET`; required in prod. |
 | On-device hashing in PROVISIONING_CONSOLE | The ProvisioningFSM hashes the raw credential UID on-device (SHA-256 via mbedTLS) before publishing `EVENT_PROVISION_REQUEST`. The raw UID never leaves the ESP32, even over an encrypted channel. |

--- a/docs/ci_cd_pipeline.md
+++ b/docs/ci_cd_pipeline.md
@@ -29,10 +29,10 @@ The pipeline is driven entirely by [Task](https://taskfile.dev) targets defined 
   │                      Dev Machine                            │
   │                                                             │
   │  1. VALIDATE        task ci:all                             │
-  │     go vet, gofmt, tests (race), proto drift check,         │
+  │     go vet, gofmt, tests (race), proto drift check,        │
   │     firmware compile check                                  │
   │                          │                                  │
-  │  2. BUILD                ▼                                  │
+  │  2. BUILD               ▼                                   │
   │     task build:server              (native x86_64)          │
   │     task build:server:arm64        (cross-compile for Pi)   │
   │     task firmware:build:prod       (ESP32 prod firmware)    │

--- a/docs/security.md
+++ b/docs/security.md
@@ -62,7 +62,7 @@ The current codebase is aimed at resisting:
 - casual LAN misuse
 - unauthorized module impersonation without the shared secret
 - accidental or unauthorized admin API access when the admin key is set
-- casual database inspection of stored credential hash data
+- casual database inspection of stored card data
 
 It is **not** designed to fully resist:
 
@@ -458,4 +458,4 @@ Those may be good next steps, but they are not the current implemented baseline.
 - [Server setup](setup_server.md)
 - [Firmware setup](setup_firmware.md)
 - [Access module setup and architecture](../access_module/README.md)
-- [Shared secrets setup](shared_secrets_setup.md)
+- [Shared secrets setup](../access_module/shared_secrets_setup.md)

--- a/server/internal/db/migrations/0012_seed_operator_viewer_permissions.sql
+++ b/server/internal/db/migrations/0012_seed_operator_viewer_permissions.sql
@@ -1,0 +1,38 @@
+-- Seed permissions for the operator and viewer system roles.
+--
+-- operator: day-to-day operations — provision members, manage credentials,
+--           grant and revoke module access. No destructive or administrative
+--           actions (no delete, no role/admin-user management).
+--
+-- viewer:   read-only access to members, modules, doors, credentials,
+--           module authorizations, and roles.
+--
+-- INSERT OR IGNORE makes this migration idempotent on re-application.
+
+INSERT OR IGNORE INTO role_permissions (role_id, permission, granted_at_ms)
+VALUES
+  -- operator
+  ('operator', 'module.list',              CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('operator', 'module.get',               CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('operator', 'credential.list',          CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('operator', 'credential.register',      CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('operator', 'credential.update_status', CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('operator', 'door.list',               CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('operator', 'member.provision',         CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('operator', 'member.list',              CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('operator', 'member.view',              CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('operator', 'member.assign_role',       CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('operator', 'member.disable',           CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('operator', 'module_auth.grant',        CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('operator', 'module_auth.revoke',       CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('operator', 'module_auth.list',         CAST(strftime('%s','now') AS INTEGER) * 1000),
+
+  -- viewer
+  ('viewer', 'module.list',              CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('viewer', 'module.get',               CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('viewer', 'credential.list',          CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('viewer', 'door.list',               CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('viewer', 'member.list',              CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('viewer', 'member.view',              CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('viewer', 'module_auth.list',         CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('viewer', 'role.list',                CAST(strftime('%s','now') AS INTEGER) * 1000);

--- a/server/internal/db/migrations/0013_audit_log.sql
+++ b/server/internal/db/migrations/0013_audit_log.sql
@@ -1,0 +1,27 @@
+-- Audit log table.
+--
+-- Records every state-changing action performed through the admin API.
+-- actor_uuid is nullable to accommodate future system-generated events.
+-- details holds a JSON blob with action-specific context (e.g. which fields
+-- changed, previous values).
+-- result distinguishes actions that were attempted but rejected (e.g. denied
+-- by RBAC) from those that succeeded.
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS audit_log (
+  id             TEXT    PRIMARY KEY,
+  occurred_at_ms INTEGER NOT NULL,
+  actor_uuid     TEXT    REFERENCES admin_users(uuid) ON DELETE SET NULL,
+  action         TEXT    NOT NULL,
+  resource_type  TEXT,
+  resource_id    TEXT,
+  details        TEXT,
+  ip_address     TEXT,
+  result         TEXT    NOT NULL DEFAULT 'success' CHECK (result IN ('success', 'failure'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_occurred   ON audit_log(occurred_at_ms);
+CREATE INDEX IF NOT EXISTS idx_audit_log_actor      ON audit_log(actor_uuid);
+CREATE INDEX IF NOT EXISTS idx_audit_log_action     ON audit_log(action);
+CREATE INDEX IF NOT EXISTS idx_audit_log_resource   ON audit_log(resource_type, resource_id);

--- a/server/internal/db/migrations/0014_seed_audit_log_permissions.sql
+++ b/server/internal/db/migrations/0014_seed_audit_log_permissions.sql
@@ -1,0 +1,12 @@
+-- Seed audit_log.list permission for admin, operator, and viewer roles.
+--
+-- All three staff roles can read the audit log; write access is implicit
+-- (the server writes entries directly, not through RBAC-checked API calls).
+--
+-- INSERT OR IGNORE makes this migration idempotent on re-application.
+
+INSERT OR IGNORE INTO role_permissions (role_id, permission, granted_at_ms)
+VALUES
+  ('admin',    'audit_log.list', CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('operator', 'audit_log.list', CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('viewer',   'audit_log.list', CAST(strftime('%s','now') AS INTEGER) * 1000);

--- a/server/internal/portunus/permissions/permissions.go
+++ b/server/internal/portunus/permissions/permissions.go
@@ -48,6 +48,9 @@ const (
 	ModuleAuthGrant  = "module_auth.grant"
 	ModuleAuthRevoke = "module_auth.revoke"
 	ModuleAuthList   = "module_auth.list"
+
+	// Audit log
+	AuditLogList = "audit_log.list"
 )
 
 // All returns every defined permission. Used to seed the admin role and to
@@ -61,5 +64,6 @@ func All() []string {
 		RoleList, RoleCreate, RoleEdit, RoleDelete, RoleAssignPermission,
 		MemberProvision, MemberList, MemberView, MemberAssignRole, MemberDisable, MemberArchive,
 		ModuleAuthGrant, ModuleAuthRevoke, ModuleAuthList,
+		AuditLogList,
 	}
 }


### PR DESCRIPTION
4 files changed:

[0012_seed_operator_viewer_permissions.sql](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/server/internal/db/migrations/0012_seed_operator_viewer_permissions.sql) — seeds 14 permissions for operator and 8 for viewer
[0013_audit_log.sql](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/server/internal/db/migrations/0013_audit_log.sql) — creates the audit_log table with indexes on timestamp, actor, action, and resource
[0014_seed_audit_log_permissions.sql](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/server/internal/db/migrations/0014_seed_audit_log_permissions.sql) — grants audit_log.list to admin, operator, and viewer
[permissions.go](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/server/internal/portunus/permissions/permissions.go) — adds AuditLogList = "audit_log.list" constant and includes it in All() so it appears in the UI checkbox grid