### PR TITLE
make a missing member-access or module fail at startup

### DIFF
--- a/server/cmd/portunus-server/main.go
+++ b/server/cmd/portunus-server/main.go
@@ -86,19 +86,9 @@ func main() {
 	pruner.Start(ctx)
 	defer pruner.Stop()
 
-	allowed := make(map[string]struct{}, len(cfg.AllowedCredentialIDs))
-	for _, c := range cfg.AllowedCredentialIDs {
-		allowed[c] = struct{}{}
-	}
 	accessSvc := service.NewAccessService(registry, service.AccessPolicy{
-		AllowAll:             cfg.AllowAll,
-		AllowedCredentialIDs: allowed,
+		AllowAll: cfg.AllowAll,
 	}, accessEventStore)
-
-	// Enable DB-backed credential lookups (replaces the legacy AllowedCredentialIDs
-	// env-var map).  When credentials exist in the DB, the access service
-	// hashes the incoming credential ID and checks the credentials table.
-	accessSvc.SetCredentialStore(credentialStore)
 
 	credentialHashSecret := []byte(cfg.CredentialHashSecret)
 	if cfg.CredentialHashSecret == "" {
@@ -114,6 +104,9 @@ func main() {
 	// Enable member_access + module_authorizations path in the access service.
 	accessSvc.SetMemberAccessStore(memberAccessStore)
 	accessSvc.SetModuleAuthStore(moduleAuthStore)
+	if err := accessSvc.Validate(); err != nil {
+		logger.Fatalf("access service wiring error: %v", err)
+	}
 
 	// Expiry worker: transitions member records to 'expired' on a scheduled interval.
 	expiryWorker := service.NewExpiryWorker(memberAccessStore, service.ExpiryWorkerConfig{

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -16,9 +16,8 @@ type Config struct {
 	Env    string // "dev" | "prod"
 	DBPath string // e.g. "./data/portunus.db"
 
-	KnownModules         []string
-	AllowAll             bool
-	AllowedCredentialIDs []string
+	KnownModules []string
+	AllowAll     bool
 
 	// Heartbeat retention
 	HeartbeatRetentionDays int // 0 = keep forever
@@ -86,8 +85,6 @@ func FromEnv() (Config, error) {
 	dbPath := getenvDefault("PORTUNUS_DB_PATH", "./data/portunus.db")
 
 	knownModules := splitCSV(os.Getenv("PORTUNUS_KNOWN_MODULES"))
-	allowedCredentials := splitCSV(os.Getenv("PORTUNUS_ALLOWED_CREDENTIAL_IDS"))
-
 	allowAll := strings.EqualFold(os.Getenv("PORTUNUS_ALLOW_ALL"), "true") ||
 		os.Getenv("PORTUNUS_ALLOW_ALL") == "1"
 
@@ -107,9 +104,8 @@ func FromEnv() (Config, error) {
 		Env:      env,
 		DBPath:   dbPath,
 
-		KnownModules:         knownModules,
-		AllowAll:             allowAll,
-		AllowedCredentialIDs: allowedCredentials,
+		KnownModules: knownModules,
+		AllowAll:     allowAll,
 
 		HeartbeatRetentionDays:      retentionDays,
 		PruneIntervalHours:          pruneInterval,

--- a/server/internal/httpapi/server_test.go
+++ b/server/internal/httpapi/server_test.go
@@ -157,33 +157,23 @@ func TestAccessRequest_AllowAll_Granted(t *testing.T) {
 	}
 }
 
-func TestAccessRequest_CredentialNotAllowed_Denied(t *testing.T) {
-	allowed := map[string]struct{}{"AABBCCDD": {}}
-	ts := newTestServer(t, []string{"door-001"}, service.AccessPolicy{
-		AllowedCredentialIDs: allowed,
-	})
+// TestAccessRequest_MisconfiguredService_Returns500 verifies that the HTTP
+// handler returns 500 (not a silent grant) when the access service is not
+// fully wired — both member-access and module-auth stores must be set.
+func TestAccessRequest_MisconfiguredService_Returns500(t *testing.T) {
+	ts := newTestServer(t, []string{"door-001"}, service.AccessPolicy{})
+	// newTestServer does not wire memberAccessStore or moduleAuthStore,
+	// so Decide will return an internal error.
 
-	body := []byte(`{"module_id":"door-001","credential_id":"UNKNOWN_CREDENTIAL"}`)
+	body := []byte(`{"module_id":"door-001","credential_id":"04:AA:BB:CC"}`)
 	resp, err := http.Post(ts.URL+"/v1/access_request", "application/json", bytes.NewReader(body))
 	if err != nil {
 		t.Fatalf("post: %v", err)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
-	}
-
-	var ar types.AccessResponse
-	if err := json.NewDecoder(resp.Body).Decode(&ar); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-
-	if ar.Granted {
-		t.Error("expected granted=false for unknown credential")
-	}
-	if ar.Reason != "credential_not_allowed" {
-		t.Errorf("expected reason=credential_not_allowed, got %q", ar.Reason)
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500 for misconfigured service, got %d", resp.StatusCode)
 	}
 }
 

--- a/server/internal/portunus/service/access_service.go
+++ b/server/internal/portunus/service/access_service.go
@@ -36,16 +36,12 @@ var (
 type AccessPolicy struct {
 	// AllowAll grants access to any credential (dev/testing only).
 	AllowAll bool
-	// AllowedCredentialIDs is the legacy env-var allowlist (deprecated).
-	// When CredentialStore is set, this is ignored.
-	AllowedCredentialIDs map[string]struct{}
 }
 
 type AccessService struct {
 	registry             *DeviceRegistry
 	policy               AccessPolicy
 	eventStore           store.AccessEventStore
-	credentialStore      store.CredentialStore // nil = use legacy AllowedCredentialIDs map
 	memberAccessStore    store.MemberAccessStore
 	moduleAuthStore      store.ModuleAuthorizationStore
 	credentialHashSecret []byte
@@ -81,15 +77,8 @@ func (s *AccessService) AuditHealth() AuditHealthSnapshot {
 	return snap
 }
 
-// SetCredentialStore enables DB-backed credential lookups, replacing the legacy
-// AllowedCredentialIDs map. Call after NewAccessService, before serving traffic.
-func (s *AccessService) SetCredentialStore(cs store.CredentialStore) {
-	s.credentialStore = cs
-}
-
-// SetMemberAccessStore enables the member_access + module_authorizations access path.
-// When both this and SetModuleAuthStore are set, this path takes priority over
-// the legacy credential store path.
+// SetMemberAccessStore wires the member_access store required for access decisions.
+// Must be called (along with SetModuleAuthStore) before calling Validate.
 func (s *AccessService) SetMemberAccessStore(ms store.MemberAccessStore) {
 	s.memberAccessStore = ms
 }
@@ -103,6 +92,22 @@ func (s *AccessService) SetModuleAuthStore(mas store.ModuleAuthorizationStore) {
 // match the key used at registration time. Call after NewAccessService, before serving traffic.
 func (s *AccessService) SetCredentialHashSecret(secret []byte) {
 	s.credentialHashSecret = secret
+}
+
+// Validate returns an error if the service is not fully wired for production use.
+// Call this after all Set* calls and before serving traffic; treat a non-nil return
+// as a fatal configuration error.  AllowAll bypasses the check (dev/test only).
+func (s *AccessService) Validate() error {
+	if s.policy.AllowAll {
+		return nil
+	}
+	if s.memberAccessStore == nil {
+		return errors.New("access service: SetMemberAccessStore was not called")
+	}
+	if s.moduleAuthStore == nil {
+		return errors.New("access service: SetModuleAuthStore was not called")
+	}
+	return nil
 }
 
 func (s *AccessService) Decide(ctx context.Context, req types.AccessRequest) (types.AccessResponse, error) {
@@ -168,39 +173,13 @@ func (s *AccessService) Decide(ctx context.Context, req types.AccessRequest) (ty
 			return types.AccessResponse{}, err
 		}
 		granted, reason, grantedMemberUUID = g, r, memberUUID
-	} else if s.credentialStore != nil {
-		// Legacy DB-backed credential lookup.
-		rawUID, parseErr := ParseCredentialUID(credentialID)
-		if parseErr != nil {
-			s.recordEvent(ctx, req, false, "invalid_credential_format", now)
-			return types.AccessResponse{
-				OK:         true,
-				Known:      true,
-				Granted:    false,
-				Reason:     "invalid_credential_format",
-				ModuleID:   moduleID,
-				ServerTime: now.Format(time.RFC3339Nano),
-			}, nil
-		}
-		allowed, err := s.credentialStore.IsCredentialAllowed(ctx, HashCredentialID(rawUID, s.credentialHashSecret))
-		if err != nil {
-			s.recordEvent(ctx, req, false, "credential_lookup_error", now)
-			return types.AccessResponse{}, err
-		}
-		if allowed {
-			granted = true
-			reason = "credential_allowed"
-		} else {
-			reason = "credential_not_allowed"
-		}
 	} else {
-		// Legacy env-var allowlist fallback.
-		if _, ok := s.policy.AllowedCredentialIDs[credentialID]; ok {
-			granted = true
-			reason = "credential_allowed"
-		} else {
-			reason = "credential_not_allowed"
-		}
+		// Both member-access and module-auth stores are required; reaching here means
+		// Validate() was not called (or was ignored) before serving traffic.
+		// Deny and surface as an internal error — never silently fall through to a
+		// credential-only path that skips per-module authorization.
+		s.recordEvent(ctx, req, false, "service_misconfigured", now)
+		return types.AccessResponse{}, errors.New("access service: not fully wired — call Validate() before serving")
 	}
 
 	if granted && grantedMemberUUID != "" {

--- a/server/internal/portunus/service/access_service_member_test.go
+++ b/server/internal/portunus/service/access_service_member_test.go
@@ -676,3 +676,57 @@ func TestAccess_FirmwareEnrolledCredential_IsGranted(t *testing.T) {
 		t.Errorf("expected granted=true for firmware-enrolled credential, got reason=%q", resp.Reason)
 	}
 }
+
+// ── fail-open regression test ─────────────────────────────────────────────────
+
+// TestAccessService_FailOpen_UnauthorizedModuleIsDenied is the wiring regression
+// guard required by P1-1.  It constructs the service the same way main.go does
+// (both member-access and module-auth stores wired) and asserts that a member
+// whose credential IS enrolled but has NO module authorization is denied with
+// reason "module_not_authorized".
+//
+// If moduleAuthStore were ever accidentally removed from the wiring, the service
+// would error out (branch 3/4 hard-error path), not silently grant.  If the
+// member-access path were accidentally replaced with a credential-only path, this
+// test would catch the regression: "credential_allowed" would appear instead of
+// "module_not_authorized".
+func TestAccessService_FailOpen_UnauthorizedModuleIsDenied(t *testing.T) {
+	ctx := context.Background()
+	dbConn, writer := openSvcTestDB(t)
+	maStore := sqlitestore.NewMemberAccessStore(dbConn, writer)
+	moStore := sqlitestore.NewModuleAuthorizationStore(dbConn, writer)
+	moduleID := "module-guard"
+	memberUUID := "cccccccc-0000-4000-8000-000000000001"
+
+	credHash := service.HashCredentialID([]byte{0x04, 0xBB, 0xCC, 0xDD}, nil)
+
+	if err := maStore.CreateMember(ctx, memberUUID, "member", "", store.ProvisioningStatusActive, nil, nil); err != nil {
+		t.Fatalf("CreateMember: %v", err)
+	}
+	if err := maStore.AttachCredential(ctx, memberUUID, credHash); err != nil {
+		t.Fatalf("AttachCredential: %v", err)
+	}
+	// Intentionally no GrantAuthorization — the member has a credential but no module access.
+
+	deviceStore := memory.NewDeviceStore([]string{moduleID})
+	svc := service.NewAccessService(service.NewDeviceRegistry(deviceStore), service.AccessPolicy{}, memory.NewAccessEventStore())
+	svc.SetMemberAccessStore(maStore)
+	svc.SetModuleAuthStore(moStore)
+	if err := svc.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	resp, err := svc.Decide(ctx, types.AccessRequest{
+		ModuleID:     moduleID,
+		CredentialID: "04:BB:CC:DD",
+	})
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if resp.Granted {
+		t.Error("enrolled member with no module authorization must not be granted")
+	}
+	if resp.Reason != "module_not_authorized" {
+		t.Errorf("expected reason=module_not_authorized, got %q — wiring regression?", resp.Reason)
+	}
+}

--- a/server/internal/portunus/service/access_service_test.go
+++ b/server/internal/portunus/service/access_service_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/service"
 	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/store/memory"
+	sqlitestore "github.com/BrandonDHaskell/Portunus/server/internal/portunus/store/sqlite"
 	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/types"
 )
 
@@ -58,58 +59,83 @@ func TestDecide_AllowAll_RecordsGrantEvent(t *testing.T) {
 	}
 }
 
-func TestDecide_CredentialAllowed_RecordsGrantEvent(t *testing.T) {
-	allowed := map[string]struct{}{"AABBCCDD": {}}
-	svc, es := newTestAccessService(
-		[]string{"door-001"},
-		service.AccessPolicy{AllowedCredentialIDs: allowed},
-	)
+// TestDecide_MisconfiguredService_ReturnsError verifies that Decide returns a
+// hard error (rather than silently granting) when the service is not fully wired.
+// This guards against accidentally falling through to a credential-only path
+// that skips per-module authorization.
+func TestDecide_MisconfiguredService_ReturnsError(t *testing.T) {
+	svc, es := newTestAccessService([]string{"door-001"}, service.AccessPolicy{})
+	// Neither memberAccessStore nor moduleAuthStore is set — service is misconfigured.
 
 	_, err := svc.Decide(context.Background(), types.AccessRequest{
 		ModuleID:     "door-001",
-		CredentialID: "AABBCCDD",
+		CredentialID: "04:AA:BB:CC",
 	})
-	if err != nil {
-		t.Fatalf("Decide: %v", err)
+	if err == nil {
+		t.Fatal("expected error from misconfigured service, got nil")
 	}
 
+	// An audit event must still be recorded even when Decide returns an error.
 	events := es.Events()
 	if len(events) != 1 {
-		t.Fatalf("expected 1 event, got %d", len(events))
+		t.Fatalf("expected 1 audit event, got %d", len(events))
 	}
-	if !events[0].Granted {
-		t.Error("expected granted=true for allowed credential")
-	}
-	if events[0].Reason != "credential_allowed" {
-		t.Errorf("expected reason=credential_allowed, got %q", events[0].Reason)
+	if events[0].Granted {
+		t.Error("misconfigured service must not grant")
 	}
 }
 
-func TestDecide_CredentialDenied_RecordsDenyEvent(t *testing.T) {
-	allowed := map[string]struct{}{"AABBCCDD": {}}
-	svc, es := newTestAccessService(
-		[]string{"door-001"},
-		service.AccessPolicy{AllowedCredentialIDs: allowed},
-	)
+// TestAccessService_Validate tests that Validate catches missing stores and
+// passes when both are present or when AllowAll is set.
+func TestAccessService_Validate(t *testing.T) {
+	newSvc := func(policy service.AccessPolicy) *service.AccessService {
+		ds := memory.NewDeviceStore(nil)
+		return service.NewAccessService(
+			service.NewDeviceRegistry(ds),
+			policy,
+			memory.NewAccessEventStore(),
+		)
+	}
 
-	_, err := svc.Decide(context.Background(), types.AccessRequest{
-		ModuleID:     "door-001",
-		CredentialID: "UNKNOWN_CREDENTIAL",
+	t.Run("missing both stores", func(t *testing.T) {
+		if err := newSvc(service.AccessPolicy{}).Validate(); err == nil {
+			t.Error("expected error when neither store is set")
+		}
 	})
-	if err != nil {
-		t.Fatalf("Decide: %v", err)
-	}
 
-	events := es.Events()
-	if len(events) != 1 {
-		t.Fatalf("expected 1 event, got %d", len(events))
-	}
-	if events[0].Granted {
-		t.Error("expected granted=false for denied credential")
-	}
-	if events[0].Reason != "credential_not_allowed" {
-		t.Errorf("expected reason=credential_not_allowed, got %q", events[0].Reason)
-	}
+	t.Run("missing moduleAuthStore", func(t *testing.T) {
+		dbConn, writer := openSvcTestDB(t)
+		svc := newSvc(service.AccessPolicy{})
+		svc.SetMemberAccessStore(sqlitestore.NewMemberAccessStore(dbConn, writer))
+		if err := svc.Validate(); err == nil {
+			t.Error("expected error when moduleAuthStore is missing")
+		}
+	})
+
+	t.Run("missing memberAccessStore", func(t *testing.T) {
+		dbConn, writer := openSvcTestDB(t)
+		svc := newSvc(service.AccessPolicy{})
+		svc.SetModuleAuthStore(sqlitestore.NewModuleAuthorizationStore(dbConn, writer))
+		if err := svc.Validate(); err == nil {
+			t.Error("expected error when memberAccessStore is missing")
+		}
+	})
+
+	t.Run("fully wired", func(t *testing.T) {
+		dbConn, writer := openSvcTestDB(t)
+		svc := newSvc(service.AccessPolicy{})
+		svc.SetMemberAccessStore(sqlitestore.NewMemberAccessStore(dbConn, writer))
+		svc.SetModuleAuthStore(sqlitestore.NewModuleAuthorizationStore(dbConn, writer))
+		if err := svc.Validate(); err != nil {
+			t.Errorf("expected nil error when fully wired, got: %v", err)
+		}
+	})
+
+	t.Run("AllowAll bypasses check", func(t *testing.T) {
+		if err := newSvc(service.AccessPolicy{AllowAll: true}).Validate(); err != nil {
+			t.Errorf("expected AllowAll to bypass Validate, got: %v", err)
+		}
+	})
 }
 
 func TestDecide_UnknownModule_RecordsDenyEvent(t *testing.T) {


### PR DESCRIPTION
access_service.go

Removed credentialStore field and SetCredentialStore method
Removed AllowedCredentialIDs from AccessPolicy
Replaced legacy branches 3 and 4 with a single hard error (service_misconfigured): records an audit event and returns an error — never silently grants or falls through to a credential-only path
Added Validate() error: returns an error if memberAccessStore or moduleAuthStore is nil (bypassed by AllowAll)
config.go

Removed AllowedCredentialIDs []string field and PORTUNUS_ALLOWED_CREDENTIAL_IDS env-var loading
main.go

Removed allowed map and AllowedCredentialIDs from NewAccessService call
Removed SetCredentialStore(credentialStore) call
Added accessSvc.Validate() after the two Set* calls — logger.Fatalf if stores are missing
Tests

Removed TestDecide_CredentialAllowed_RecordsGrantEvent and TestDecide_CredentialDenied_RecordsDenyEvent (tested removed code)
Replaced TestAccessRequest_CredentialNotAllowed_Denied with TestAccessRequest_MisconfiguredService_Returns500 (verifies the HTTP handler returns 500, not a silent grant)
Added TestAccessService_Validate (five subtests covering all Validate() branches)
Added TestAccessService_FailOpen_UnauthorizedModuleIsDenied — the explicit P1-1 regression guard: enroll a member, skip GrantAuthorization, assert module_not_authorized; if moduleAuthStore were ever unwired, credential_allowed would appear and this test would catch it