### PR TITLE
fixed provisioning credentials now validate with server db

### DIFF
--- a/access_module/components/portunus_proto/portunus/v1/portunus.pb.h
+++ b/access_module/components/portunus_proto/portunus/v1/portunus.pb.h
@@ -104,20 +104,30 @@ typedef struct _portunus_v1_AccessResponse {
 } portunus_v1_AccessResponse;
 
 typedef PB_BYTES_ARRAY_T(10) portunus_v1_ProvisionCredentialRequest_credential_uid_t;
+typedef PB_BYTES_ARRAY_T(10) portunus_v1_ProvisionCredentialRequest_operator_credential_uid_t;
 /* Sent by a provisioning console after a successful two-scan flow.
- The device sends the raw RFID UID bytes; the server applies HMAC-SHA256.
+ The device sends raw RFID UID bytes for both scans; the server applies
+ HMAC-SHA256 and resolves the scan-1 UID to an admin user for attribution.
 
  Server Go equivalent: types.ProvisionCredentialRequest */
 typedef struct _portunus_v1_ProvisionCredentialRequest {
-    /* UUID of the operator performing the provisioning (from scan 1). */
+    /* UUID of the admin operator.  Populated by the server after resolving
+ operator_credential_uid (field 6) to an admin_users record.
+ When field 6 is absent (legacy firmware), the device supplies this
+ directly from Kconfig CONFIG_PORTUNUS_OPERATOR_UUID. */
     char operator_uuid[37];
     /* Module ID of the provisioning console. */
     char module_id[33];
     /* Role ID to assign to the new member.  Must already exist on the server. */
     char role_id[33];
-    /* Raw RFID UID bytes read from the card (1–10 bytes).
+    /* Raw RFID UID bytes read from the new-member card (scan 2, 1–10 bytes).
  The server computes HMAC-SHA256(secret, credential_uid) before storing. */
     portunus_v1_ProvisionCredentialRequest_credential_uid_t credential_uid;
+    /* Raw RFID UID bytes read from the operator's card (scan 1, 1–10 bytes).
+ The server hashes this and looks up the matching admin_user_credentials
+ row to determine the true operator identity.  When present, this takes
+ precedence over operator_uuid (field 1). */
+    portunus_v1_ProvisionCredentialRequest_operator_credential_uid_t operator_credential_uid;
 } portunus_v1_ProvisionCredentialRequest;
 
 /* Returned by the server after processing a provisioning request.
@@ -154,13 +164,13 @@ extern "C" {
 #define portunus_v1_HeartbeatResponse_init_default {0, 0, "", ""}
 #define portunus_v1_AccessRequest_init_default   {"", "", false, 0, ""}
 #define portunus_v1_AccessResponse_init_default  {0, 0, 0, "", "", ""}
-#define portunus_v1_ProvisionCredentialRequest_init_default {"", "", "", {0, {0}}}
+#define portunus_v1_ProvisionCredentialRequest_init_default {"", "", "", {0, {0}}, {0, {0}}}
 #define portunus_v1_ProvisionCredentialResponse_init_default {"", _portunus_v1_ProvisionStatus_MIN, ""}
 #define portunus_v1_HeartbeatRequest_init_zero   {"", "", 0, false, 0, false, 0, "", 0, 0}
 #define portunus_v1_HeartbeatResponse_init_zero  {0, 0, "", ""}
 #define portunus_v1_AccessRequest_init_zero      {"", "", false, 0, ""}
 #define portunus_v1_AccessResponse_init_zero     {0, 0, 0, "", "", ""}
-#define portunus_v1_ProvisionCredentialRequest_init_zero {"", "", "", {0, {0}}}
+#define portunus_v1_ProvisionCredentialRequest_init_zero {"", "", "", {0, {0}}, {0, {0}}}
 #define portunus_v1_ProvisionCredentialResponse_init_zero {"", _portunus_v1_ProvisionStatus_MIN, ""}
 
 /* Field tags (for use in manual encoding/decoding) */
@@ -190,6 +200,7 @@ extern "C" {
 #define portunus_v1_ProvisionCredentialRequest_module_id_tag 2
 #define portunus_v1_ProvisionCredentialRequest_role_id_tag 4
 #define portunus_v1_ProvisionCredentialRequest_credential_uid_tag 5
+#define portunus_v1_ProvisionCredentialRequest_operator_credential_uid_tag 6
 #define portunus_v1_ProvisionCredentialResponse_member_uuid_tag 1
 #define portunus_v1_ProvisionCredentialResponse_status_tag 2
 #define portunus_v1_ProvisionCredentialResponse_detail_tag 3
@@ -237,7 +248,8 @@ X(a, STATIC,   SINGULAR, STRING,   server_time,       6)
 X(a, STATIC,   SINGULAR, STRING,   operator_uuid,     1) \
 X(a, STATIC,   SINGULAR, STRING,   module_id,         2) \
 X(a, STATIC,   SINGULAR, STRING,   role_id,           4) \
-X(a, STATIC,   SINGULAR, BYTES,    credential_uid,    5)
+X(a, STATIC,   SINGULAR, BYTES,    credential_uid,    5) \
+X(a, STATIC,   SINGULAR, BYTES,    operator_credential_uid,   6)
 #define portunus_v1_ProvisionCredentialRequest_CALLBACK NULL
 #define portunus_v1_ProvisionCredentialRequest_DEFAULT NULL
 
@@ -269,7 +281,7 @@ extern const pb_msgdesc_t portunus_v1_ProvisionCredentialResponse_msg;
 #define portunus_v1_AccessResponse_size          115
 #define portunus_v1_HeartbeatRequest_size        142
 #define portunus_v1_HeartbeatResponse_size       79
-#define portunus_v1_ProvisionCredentialRequest_size 118
+#define portunus_v1_ProvisionCredentialRequest_size 130
 #define portunus_v1_ProvisionCredentialResponse_size 105
 
 #ifdef __cplusplus

--- a/access_module/components/portunus_types/include/event_types.h
+++ b/access_module/components/portunus_types/include/event_types.h
@@ -116,10 +116,11 @@ typedef enum {
  * server_comm encodes this into a ProvisionCredentialRequest and sends it.
  */
 typedef struct {
-    char    operator_uuid[37];    /**< Pre-configured operator UUID (from Kconfig) */
-    uint8_t credential_uid[10];   /**< Raw RFID UID bytes (server applies HMAC-SHA256) */
-    uint8_t credential_uid_len;   /**< Number of valid bytes in credential_uid (1–10) */
-    char    role_id[33];          /**< Role ID to assign to the new member */
+    uint8_t operator_credential_uid[10]; /**< Raw RFID UID bytes from scan-1 (operator badge) */
+    uint8_t operator_credential_uid_len; /**< Number of valid bytes in operator_credential_uid (1–10) */
+    uint8_t credential_uid[10];          /**< Raw RFID UID bytes from scan-2 (new member card) */
+    uint8_t credential_uid_len;          /**< Number of valid bytes in credential_uid (1–10) */
+    char    role_id[33];                 /**< Role ID to assign to the new member */
 } event_provision_request_t;
 
 /**

--- a/access_module/core/provisioning_fsm/include/provisioning_fsm.h
+++ b/access_module/core/provisioning_fsm/include/provisioning_fsm.h
@@ -20,15 +20,15 @@
  *                          │                             │
  *                        IDLE ◄──────────────────────── IDLE
  *
- * Scan 1 (in IDLE): any credential read advances the FSM and starts the
- * mandatory timeout. The credential is discarded — it serves only as a
- * physical presence confirmation.
+ * Scan 1 (in IDLE): the operator taps their registered admin badge. The raw
+ * UID bytes are stored in m_operator_cred and the FSM advances to
+ * AWAITING_CREDENTIAL, starting the mandatory timeout.
  *
- * Scan 2 (in AWAITING_CREDENTIAL): the new credential's raw UID bytes are
- * SHA-256 hashed on-device via mbedTLS. The hash, the pre-configured
- * operator UUID (Kconfig), and the default role ID are bundled into an
- * EVENT_PROVISION_REQUEST and published to the event bus. server_comm
- * encodes and sends the ProvisionCredentialRequest RPC.
+ * Scan 2 (in AWAITING_CREDENTIAL): the new member card is tapped. The
+ * scan-1 operator UID (m_operator_cred) and scan-2 member UID are bundled
+ * into an EVENT_PROVISION_REQUEST and published to the event bus. server_comm
+ * encodes and sends the ProvisionCredentialRequest RPC; the server resolves
+ * the scan-1 UID to an admin user for attribution.
  *
  * Architecture layer: Core / FSM (mirrors system_fsm architecture).
  */
@@ -96,8 +96,9 @@ private:
     bool m_has_network  = false;
 
     /* ── FSM state ────────────────────────────────────────────────────────── */
-    prov_state_t m_prov_state        = PROV_STATE_IDLE;
+    prov_state_t m_prov_state          = PROV_STATE_IDLE;
     int64_t      m_timeout_deadline_ms = 0;
+    credential_t m_operator_cred       = {};  /**< Scan-1 operator badge UID */
 
     /* ── FreeRTOS handles ─────────────────────────────────────────────────── */
     TaskHandle_t  m_fsm_task_handle  = nullptr;

--- a/access_module/core/provisioning_fsm/src/provisioning_fsm.cpp
+++ b/access_module/core/provisioning_fsm/src/provisioning_fsm.cpp
@@ -3,17 +3,17 @@
  * @brief Provisioning console FSM implementation.
  *
  * Two-scan flow:
- *   1. Any credential read in IDLE → start 30s timeout, move to AWAITING.
- *   2. Any credential read in AWAITING → copy raw UID bytes into
- *      EVENT_PROVISION_REQUEST, move to SENDING.  The server applies
- *      HMAC-SHA256(secret, uid) before storage so enrollment and lookup use
- *      the same algorithm.
+ *   1. Credential read in IDLE → store raw UID bytes as operator badge
+ *      (m_operator_cred), start 30s timeout, move to AWAITING.
+ *   2. Credential read in AWAITING → copy scan-1 operator UID and scan-2
+ *      member UID into EVENT_PROVISION_REQUEST, move to SENDING.
+ *      The server applies HMAC-SHA256(secret, uid) for both UIDs and
+ *      resolves scan-1 to an admin user for operator attribution.
  *   3. Timeout in AWAITING → return to IDLE.
  *   4. EVENT_PROVISION_SUCCESS / EVENT_PROVISION_FAILED → show feedback,
  *      return to IDLE.
  *
- * The operator_uuid and role_id are read from Kconfig at build time and
- * embedded in every ProvisionCredentialRequest.
+ * The default role_id is read from Kconfig at build time.
  */
 
 #include "provisioning_fsm.h"
@@ -158,8 +158,8 @@ portunus_err_t ProvisioningFSM::start()
     }
 
     ESP_LOGI(TAG, "Provisioning FSM running — state=IDLE");
-    ESP_LOGI(TAG, "Operator UUID: %s  Role: %s  Timeout: %d ms",
-             CONFIG_PORTUNUS_OPERATOR_UUID,
+    ESP_LOGI(TAG, "Provisioning FSM: scan-1 = operator badge, scan-2 = new member card");
+    ESP_LOGI(TAG, "Role: %s  Timeout: %d ms",
              CONFIG_PORTUNUS_DEFAULT_ROLE_ID,
              CONFIG_PORTUNUS_PROVISION_TIMEOUT_MS);
 
@@ -240,8 +240,9 @@ void ProvisioningFSM::handle_credential_read(const event_credential_read_t *cred
     switch (m_prov_state) {
 
     case PROV_STATE_IDLE:
-        /* Scan 1: operator presence confirmed. Start timeout. */
-        ESP_LOGI(TAG, "Scan 1 (operator) — UID: %s — awaiting new credential", uid_str);
+        /* Scan 1: operator badge tap — store UID for attribution, start timeout. */
+        ESP_LOGI(TAG, "Scan 1 (operator badge) — UID: %s — awaiting new member card", uid_str);
+        m_operator_cred       = cred->credential;
         m_prov_state          = PROV_STATE_AWAITING_CREDENTIAL;
         m_timeout_deadline_ms = now_ms() + CONFIG_PORTUNUS_PROVISION_TIMEOUT_MS;
         if (m_has_feedback) {
@@ -250,8 +251,8 @@ void ProvisioningFSM::handle_credential_read(const event_credential_read_t *cred
         break;
 
     case PROV_STATE_AWAITING_CREDENTIAL: {
-        /* Scan 2: new credential. Send raw UID bytes; server applies HMAC-SHA256. */
-        ESP_LOGI(TAG, "Scan 2 (new credential) — UID: %s — sending provision request", uid_str);
+        /* Scan 2: new member card. Bundle scan-1 operator UID + scan-2 member UID. */
+        ESP_LOGI(TAG, "Scan 2 (new member card) — UID: %s — sending provision request", uid_str);
 
         if (!m_has_network) {
             ESP_LOGW(TAG, "Network unavailable — cannot provision");
@@ -263,10 +264,13 @@ void ProvisioningFSM::handle_credential_read(const event_credential_read_t *cred
         memset(&req_evt, 0, sizeof(req_evt));
         req_evt.id = EVENT_PROVISION_REQUEST;
 
-        strncpy(req_evt.payload.provision_request.operator_uuid,
-                CONFIG_PORTUNUS_OPERATOR_UUID,
-                sizeof(req_evt.payload.provision_request.operator_uuid) - 1);
+        /* Scan-1: operator badge UID (field 6 — server resolves to admin user). */
+        memcpy(req_evt.payload.provision_request.operator_credential_uid,
+               m_operator_cred.uid,
+               m_operator_cred.uid_len);
+        req_evt.payload.provision_request.operator_credential_uid_len = m_operator_cred.uid_len;
 
+        /* Scan-2: new member card UID (field 5). */
         memcpy(req_evt.payload.provision_request.credential_uid,
                cred->credential.uid,
                cred->credential.uid_len);

--- a/access_module/main/Kconfig.projbuild
+++ b/access_module/main/Kconfig.projbuild
@@ -34,15 +34,6 @@ menu "Portunus Configuration"
                     the operator scan before returning to idle and requiring
                     the operator to scan again.
 
-            config PORTUNUS_OPERATOR_UUID
-                string "Operator UUID"
-                default ""
-                help
-                    UUID of the member_access record authorised to use this
-                    provisioning console. Must match a record that has the
-                    credential.provision_guest permission assigned on the server.
-                    Generate with: uuidgen
-
             config PORTUNUS_DEFAULT_ROLE_ID
                 string "Default role ID for provisioned members"
                 default "guest"

--- a/access_module/services/server_comm/src/server_comm.cpp
+++ b/access_module/services/server_comm/src/server_comm.cpp
@@ -612,13 +612,18 @@ static void handle_provision(const event_provision_request_t *req)
     portunus_v1_ProvisionCredentialRequest pb_req =
         portunus_v1_ProvisionCredentialRequest_init_zero;
 
-    strncpy(pb_req.operator_uuid, req->operator_uuid,
-            sizeof(pb_req.operator_uuid) - 1);
     strncpy(pb_req.module_id, PORTUNUS_MODULE_ID,
             sizeof(pb_req.module_id) - 1);
     strncpy(pb_req.role_id, req->role_id,
             sizeof(pb_req.role_id) - 1);
 
+    /* Scan-1: operator badge UID — server resolves to admin user. */
+    pb_req.operator_credential_uid.size = req->operator_credential_uid_len;
+    memcpy(pb_req.operator_credential_uid.bytes,
+           req->operator_credential_uid,
+           req->operator_credential_uid_len);
+
+    /* Scan-2: new member card UID — server applies HMAC-SHA256 before storing. */
     pb_req.credential_uid.size = req->credential_uid_len;
     memcpy(pb_req.credential_uid.bytes, req->credential_uid, req->credential_uid_len);
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -131,7 +131,13 @@ Credential tap event — the module sends the credential UID and receives a gran
 
 ### POST /v1/provision_credential
 
-Used by PROVISIONING_CONSOLE firmware variant to enroll a new credential on the server. The firmware sends the raw UID bytes in the `credential_uid` proto field; the server applies HMAC-SHA256 server-side using `PORTUNUS_CREDENTIAL_HASH_SECRET` so that the resulting hash is identical to the one produced by the admin UI enrollment path.
+Used by PROVISIONING_CONSOLE firmware variant to enroll a new credential on the server.
+
+The firmware sends raw RFID UID bytes for both scans:
+- **`operator_credential_uid`** (proto field 6) — scan-1: operator's badge. The server hashes this and resolves it against `admin_user_credentials` to identify the operator. The resolved admin UUID is recorded in the new member's `created_by_uuid`.
+- **`credential_uid`** (proto field 5) — scan-2: new member card. The server applies `HMAC-SHA256(PORTUNUS_CREDENTIAL_HASH_SECRET, credential_uid)` before storing, producing the same hash as the admin UI enrollment path.
+
+The operator must have their RFID badge registered via `POST /admin/v1/admin-users/{uuid}/credential` before provisioning will succeed.
 
 ---
 
@@ -560,6 +566,32 @@ Revoke a member's access to a module. Records `revoked_at` and `revoked_by_uuid`
 List all module authorizations for a member.
 
 **Response (200):** Same shape as `GET /admin/v1/modules/{module_id}/authorizations`.
+
+---
+
+### Admin User Credentials
+
+An admin user may register one or more RFID badges. When that admin operates a provisioning console, the scan-1 tap of their badge is resolved server-side to their account, providing genuine operator attribution on provisioned members.
+
+#### POST /admin/v1/admin-users/{uuid}/credential
+
+Register an RFID badge for an admin user. Requires `admin_user.edit` permission.
+
+**Request:**
+
+```json
+{ "credential_id": "04:A3:2B:1C" }
+```
+
+**Response (201):**
+
+```json
+{ "ok": true, "admin_user_uuid": "550e8400-..." }
+```
+
+**Response (404):** Admin user not found.
+
+**Response (409):** Credential already registered to an admin user.
 
 ---
 

--- a/proto/README.md
+++ b/proto/README.md
@@ -250,13 +250,14 @@ access service.
 ### Provisioning
 
 `ProvisionCredentialRequest` is sent by the PROVISIONING_CONSOLE firmware
-variant after a successful two-scan flow.  The raw credential UID never leaves
-the device; only the SHA-256 digest (computed on-device via mbedTLS) is sent.
-It carries:
+variant after a successful two-scan flow.  Raw RFID UID bytes are sent for
+both scans; the server applies HMAC-SHA256 and resolves scan-1 to an admin
+user for attribution.  It carries:
 
-- `operator_uuid` — UUID of the admin user performing the provisioning (scan 1)
+- `operator_credential_uid` (field 6) — raw RFID UID bytes from scan-1 (operator's badge). The server hashes this and looks up the matching `admin_user_credentials` row to determine the operator identity.
+- `operator_uuid` (field 1, legacy) — only used by firmware that does not send field 6. When field 6 is present, field 1 is ignored. The server resolves the operator from field 6 and records the resolved UUID in `member_access.created_by_uuid`.
 - `module_id` — module ID of the provisioning console
-- `credential_hash` — 32-byte SHA-256 digest of the raw credential UID
+- `credential_uid` (field 5) — raw RFID UID bytes from scan-2 (new member card). The server computes HMAC-SHA256(secret, credential_uid) before storing.
 - `role_id` — role to assign to the new member (must already exist on the server)
 
 The server responds with `ProvisionCredentialResponse`:

--- a/proto/nanopb/portunus.options
+++ b/proto/nanopb/portunus.options
@@ -39,14 +39,16 @@ portunus.v1.AccessResponse.module_id                 max_size:33
 portunus.v1.AccessResponse.server_time               max_size:40
 
 # ── ProvisionCredentialRequest ──────────────────────────────────────────
-#   operator_uuid  – UUID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" = 36 + NUL
-#   module_id      – same as other messages
-#   role_id        – same headroom as module_id
-#   credential_uid – raw RFID UID bytes; ISO 14443 max UID is 10 bytes
-portunus.v1.ProvisionCredentialRequest.operator_uuid   max_size:37
-portunus.v1.ProvisionCredentialRequest.module_id       max_size:33
-portunus.v1.ProvisionCredentialRequest.role_id         max_size:33
-portunus.v1.ProvisionCredentialRequest.credential_uid  max_size:10
+#   operator_uuid           – UUID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" = 36 + NUL
+#   module_id               – same as other messages
+#   role_id                 – same headroom as module_id
+#   credential_uid          – raw RFID UID bytes; ISO 14443 max UID is 10 bytes
+#   operator_credential_uid – same format as credential_uid (scan-1 UID)
+portunus.v1.ProvisionCredentialRequest.operator_uuid            max_size:37
+portunus.v1.ProvisionCredentialRequest.module_id                max_size:33
+portunus.v1.ProvisionCredentialRequest.role_id                  max_size:33
+portunus.v1.ProvisionCredentialRequest.credential_uid           max_size:10
+portunus.v1.ProvisionCredentialRequest.operator_credential_uid  max_size:10
 
 # ── ProvisionCredentialResponse ─────────────────────────────────────────
 #   member_uuid – UUID = 36 + NUL

--- a/proto/portunus/v1/portunus.proto
+++ b/proto/portunus/v1/portunus.proto
@@ -141,15 +141,19 @@ message AccessResponse {
 // ──────────────────────────────────────────────────────────────────────────
 
 // Sent by a provisioning console after a successful two-scan flow.
-// The device sends the raw RFID UID bytes; the server applies HMAC-SHA256.
+// The device sends raw RFID UID bytes for both scans; the server applies
+// HMAC-SHA256 and resolves the scan-1 UID to an admin user for attribution.
 //
 // Server Go equivalent: types.ProvisionCredentialRequest
 message ProvisionCredentialRequest {
-  // UUID of the operator performing the provisioning (from scan 1).
-  string operator_uuid   = 1;
+  // UUID of the admin operator.  Populated by the server after resolving
+  // operator_credential_uid (field 6) to an admin_users record.
+  // When field 6 is absent (legacy firmware), the device supplies this
+  // directly from Kconfig CONFIG_PORTUNUS_OPERATOR_UUID.
+  string operator_uuid          = 1;
 
   // Module ID of the provisioning console.
-  string module_id       = 2;
+  string module_id              = 2;
 
   // Retired: was SHA-256(raw UID bytes) computed on-device.  Replaced by
   // credential_uid (field 5) so the server can apply a consistent HMAC.
@@ -157,11 +161,17 @@ message ProvisionCredentialRequest {
   reserved "credential_hash";
 
   // Role ID to assign to the new member.  Must already exist on the server.
-  string role_id         = 4;
+  string role_id                = 4;
 
-  // Raw RFID UID bytes read from the card (1–10 bytes).
+  // Raw RFID UID bytes read from the new-member card (scan 2, 1–10 bytes).
   // The server computes HMAC-SHA256(secret, credential_uid) before storing.
-  bytes  credential_uid  = 5;
+  bytes  credential_uid         = 5;
+
+  // Raw RFID UID bytes read from the operator's card (scan 1, 1–10 bytes).
+  // The server hashes this and looks up the matching admin_user_credentials
+  // row to determine the true operator identity.  When present, this takes
+  // precedence over operator_uuid (field 1).
+  bytes  operator_credential_uid = 6;
 }
 
 // Returned by the server after processing a provisioning request.

--- a/server/api/portunus/v1/portunus.pb.go
+++ b/server/api/portunus/v1/portunus.pb.go
@@ -479,22 +479,31 @@ func (x *AccessResponse) GetServerTime() string {
 }
 
 // Sent by a provisioning console after a successful two-scan flow.
-// The device sends the raw RFID UID bytes; the server applies HMAC-SHA256.
+// The device sends raw RFID UID bytes for both scans; the server applies
+// HMAC-SHA256 and resolves the scan-1 UID to an admin user for attribution.
 //
 // Server Go equivalent: types.ProvisionCredentialRequest
 type ProvisionCredentialRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// UUID of the operator performing the provisioning (from scan 1).
+	// UUID of the admin operator.  Populated by the server after resolving
+	// operator_credential_uid (field 6) to an admin_users record.
+	// When field 6 is absent (legacy firmware), the device supplies this
+	// directly from Kconfig CONFIG_PORTUNUS_OPERATOR_UUID.
 	OperatorUuid string `protobuf:"bytes,1,opt,name=operator_uuid,json=operatorUuid,proto3" json:"operator_uuid,omitempty"`
 	// Module ID of the provisioning console.
 	ModuleId string `protobuf:"bytes,2,opt,name=module_id,json=moduleId,proto3" json:"module_id,omitempty"`
 	// Role ID to assign to the new member.  Must already exist on the server.
 	RoleId string `protobuf:"bytes,4,opt,name=role_id,json=roleId,proto3" json:"role_id,omitempty"`
-	// Raw RFID UID bytes read from the card (1–10 bytes).
+	// Raw RFID UID bytes read from the new-member card (scan 2, 1–10 bytes).
 	// The server computes HMAC-SHA256(secret, credential_uid) before storing.
 	CredentialUid []byte `protobuf:"bytes,5,opt,name=credential_uid,json=credentialUid,proto3" json:"credential_uid,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Raw RFID UID bytes read from the operator's card (scan 1, 1–10 bytes).
+	// The server hashes this and looks up the matching admin_user_credentials
+	// row to determine the true operator identity.  When present, this takes
+	// precedence over operator_uuid (field 1).
+	OperatorCredentialUid []byte `protobuf:"bytes,6,opt,name=operator_credential_uid,json=operatorCredentialUid,proto3" json:"operator_credential_uid,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *ProvisionCredentialRequest) Reset() {
@@ -551,6 +560,13 @@ func (x *ProvisionCredentialRequest) GetRoleId() string {
 func (x *ProvisionCredentialRequest) GetCredentialUid() []byte {
 	if x != nil {
 		return x.CredentialUid
+	}
+	return nil
+}
+
+func (x *ProvisionCredentialRequest) GetOperatorCredentialUid() []byte {
+	if x != nil {
+		return x.OperatorCredentialUid
 	}
 	return nil
 }
@@ -657,12 +673,13 @@ const file_portunus_v1_portunus_proto_rawDesc = "" +
 	"\x06reason\x18\x04 \x01(\tR\x06reason\x12\x1b\n" +
 	"\tmodule_id\x18\x05 \x01(\tR\bmoduleId\x12\x1f\n" +
 	"\vserver_time\x18\x06 \x01(\tR\n" +
-	"serverTime\"\xb5\x01\n" +
+	"serverTime\"\xed\x01\n" +
 	"\x1aProvisionCredentialRequest\x12#\n" +
 	"\roperator_uuid\x18\x01 \x01(\tR\foperatorUuid\x12\x1b\n" +
 	"\tmodule_id\x18\x02 \x01(\tR\bmoduleId\x12\x17\n" +
 	"\arole_id\x18\x04 \x01(\tR\x06roleId\x12%\n" +
-	"\x0ecredential_uid\x18\x05 \x01(\fR\rcredentialUidJ\x04\b\x03\x10\x04R\x0fcredential_hash\"\x8c\x01\n" +
+	"\x0ecredential_uid\x18\x05 \x01(\fR\rcredentialUid\x126\n" +
+	"\x17operator_credential_uid\x18\x06 \x01(\fR\x15operatorCredentialUidJ\x04\b\x03\x10\x04R\x0fcredential_hash\"\x8c\x01\n" +
 	"\x1bProvisionCredentialResponse\x12\x1f\n" +
 	"\vmember_uuid\x18\x01 \x01(\tR\n" +
 	"memberUuid\x124\n" +

--- a/server/internal/db/migrations/0017_admin_user_credentials.sql
+++ b/server/internal/db/migrations/0017_admin_user_credentials.sql
@@ -1,0 +1,20 @@
+-- 0017: admin_user_credentials — maps RFID badge hashes to admin users
+--
+-- An admin user may register one or more RFID badges. The credential_hash is
+-- the canonical HMAC-SHA256(secret, raw_UID_bytes) value — same algorithm as
+-- member_access.credential_hash, so the same HashCredentialID function is used.
+--
+-- The provisioning FSM resolves scan-1 against this table to attribute
+-- provisioning events to the actual operator tapping their badge, replacing
+-- the prior compile-time CONFIG_PORTUNUS_OPERATOR_UUID constant.
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS admin_user_credentials (
+  credential_hash BLOB    NOT NULL PRIMARY KEY CHECK (length(credential_hash) = 32),
+  admin_user_uuid TEXT    NOT NULL REFERENCES admin_users(uuid) ON DELETE CASCADE,
+  created_at_ms   INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_admin_user_credentials_uuid
+  ON admin_user_credentials(admin_user_uuid);

--- a/server/internal/grpcapi/server.go
+++ b/server/internal/grpcapi/server.go
@@ -135,10 +135,11 @@ func (s *Server) RequestAccess(ctx context.Context, req *pb.AccessRequest) (*pb.
 
 func (s *Server) ProvisionCredential(ctx context.Context, req *pb.ProvisionCredentialRequest) (*pb.ProvisionCredentialResponse, error) {
 	domainReq := types.ProvisionCredentialRequest{
-		OperatorUUID:  req.GetOperatorUuid(),
-		ModuleID:      req.GetModuleId(),
-		CredentialUID: req.GetCredentialUid(),
-		RoleID:        req.GetRoleId(),
+		OperatorUUID:          req.GetOperatorUuid(),
+		OperatorCredentialUID: req.GetOperatorCredentialUid(),
+		ModuleID:              req.GetModuleId(),
+		CredentialUID:         req.GetCredentialUid(),
+		RoleID:                req.GetRoleId(),
 	}
 
 	resp, err := s.provisionService.Provision(ctx, domainReq)

--- a/server/internal/httpapi/admin.go
+++ b/server/internal/httpapi/admin.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/service"
+	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/store"
 	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/types"
 )
 
@@ -170,6 +171,50 @@ func (s *Server) handleAdminDeleteDoor(w http.ResponseWriter, r *http.Request) {
 
 	s.logger.Printf("admin: deleted door %q", doorID)
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "door_id": doorID, "deleted": true})
+}
+
+// ── Admin user credentials ───────────────────────────────────────────────────
+
+// handleAdminRegisterAdminCredential registers an RFID badge for an admin user.
+// The badge is identified at provisioning time via scan-1 (operator tap).
+func (s *Server) handleAdminRegisterAdminCredential(w http.ResponseWriter, r *http.Request) {
+	adminUUID := r.PathValue("admin_uuid")
+	if adminUUID == "" {
+		writeError(w, http.StatusBadRequest, "missing_admin_uuid", "admin_uuid path parameter is required")
+		return
+	}
+
+	var body struct {
+		CredentialID string `json:"credential_id"`
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxAdminBody)
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_json", "invalid JSON body")
+		return
+	}
+
+	rawUID, err := service.ParseCredentialUID(body.CredentialID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_credential_id", "credential_id must be a colon-separated hex UID (e.g. \"04:A3:2B:1C\")")
+		return
+	}
+	credHash := service.HashCredentialID(rawUID, s.credentialHashSecret)
+
+	if err := s.adminUserService.RegisterCredential(r.Context(), adminUUID, credHash); err != nil {
+		switch {
+		case errors.Is(err, service.ErrAdminUserNotFound):
+			writeError(w, http.StatusNotFound, "not_found", "admin user not found")
+		case errors.Is(err, store.ErrAdminCredentialConflict):
+			writeError(w, http.StatusConflict, "duplicate_credential", "credential is already registered to an admin user")
+		default:
+			s.logger.Printf("admin register admin credential: %v", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "failed to register credential")
+		}
+		return
+	}
+
+	s.logger.Printf("admin: registered credential for admin user %s", adminUUID)
+	writeJSON(w, http.StatusCreated, map[string]any{"ok": true, "admin_user_uuid": adminUUID})
 }
 
 // ── System health ────────────────────────────────────────────────────────────

--- a/server/internal/httpapi/convert.go
+++ b/server/internal/httpapi/convert.go
@@ -70,10 +70,11 @@ func accessResponseToProto(r types.AccessResponse) *pb.AccessResponse {
 
 func provisionRequestFromProto(p *pb.ProvisionCredentialRequest) types.ProvisionCredentialRequest {
 	return types.ProvisionCredentialRequest{
-		OperatorUUID:  p.GetOperatorUuid(),
-		ModuleID:      p.GetModuleId(),
-		CredentialUID: p.GetCredentialUid(),
-		RoleID:        p.GetRoleId(),
+		OperatorUUID:          p.GetOperatorUuid(),
+		OperatorCredentialUID: p.GetOperatorCredentialUid(),
+		ModuleID:              p.GetModuleId(),
+		CredentialUID:         p.GetCredentialUid(),
+		RoleID:                p.GetRoleId(),
 	}
 }
 

--- a/server/internal/httpapi/server.go
+++ b/server/internal/httpapi/server.go
@@ -158,6 +158,9 @@ func NewServer(d Dependencies) *Server {
 		mux.Handle("GET /admin/ui/static/", http.StripPrefix("/admin/ui/static/", staticHandler()))
 	}
 	if d.AdminUserService != nil {
+		// REST endpoint: register an admin user's RFID badge for provisioning scan-1.
+		mux.HandleFunc("POST /admin/v1/admin-users/{admin_uuid}/credential",
+			requirePermission(permissions.AdminUserEdit, s.handleAdminRegisterAdminCredential))
 		s.uiUserRoutes(mux)
 	}
 	if d.RoleService != nil {

--- a/server/internal/portunus/service/admin_user_service.go
+++ b/server/internal/portunus/service/admin_user_service.go
@@ -128,6 +128,22 @@ func (s *AdminUserService) SetEnabled(ctx context.Context, uuid, callerUUID stri
 	return nil
 }
 
+// RegisterCredential registers a credential hash for an admin user so they can
+// be identified via scan-1 during provisioning.  credentialHash must be the
+// canonical HMAC-SHA256(secret, rawUID) value produced by HashCredentialID.
+func (s *AdminUserService) RegisterCredential(ctx context.Context, adminUUID string, credentialHash []byte) error {
+	if err := s.users.RegisterAdminCredential(ctx, adminUUID, credentialHash); err != nil {
+		switch {
+		case errors.Is(err, store.ErrNotFound):
+			return ErrAdminUserNotFound
+		case errors.Is(err, store.ErrAdminCredentialConflict):
+			return err
+		}
+		return fmt.Errorf("register credential: %w", err)
+	}
+	return nil
+}
+
 // AssignRole assigns a role to an admin user.
 func (s *AdminUserService) AssignRole(ctx context.Context, uuid, roleID string) error {
 	roleID = strings.TrimSpace(roleID)

--- a/server/internal/portunus/service/provision_service.go
+++ b/server/internal/portunus/service/provision_service.go
@@ -44,12 +44,17 @@ func NewProvisionService(
 // Provision handles a ProvisionCredentialRequest from a PROVISIONING_CONSOLE module.
 // It returns a domain error only for internal failures; all provisioning outcomes
 // (duplicate, unauthorized, invalid_role) are encoded in the response Status.
+//
+// Operator resolution order:
+//  1. If OperatorCredentialUID is non-empty: hash it, look up via
+//     admin_user_credentials, and use that admin as the operator.
+//  2. If OperatorCredentialUID is empty: fall back to OperatorUUID directly
+//     (legacy firmware that sends the Kconfig UUID in field 1).
 func (s *ProvisionService) Provision(
 	ctx context.Context,
 	req types.ProvisionCredentialRequest,
 ) (types.ProvisionCredentialResponse, error) {
 	moduleID := strings.TrimSpace(req.ModuleID)
-	operatorUUID := strings.TrimSpace(req.OperatorUUID)
 	roleID := strings.TrimSpace(req.RoleID)
 
 	if moduleID == "" {
@@ -59,7 +64,7 @@ func (s *ProvisionService) Provision(
 		return types.ProvisionCredentialResponse{}, ErrProvisionCredentialUIDRequired
 	}
 
-	// Hash the raw UID bytes server-side so enrollment and lookup use the same algorithm.
+	// Hash the scan-2 raw UID bytes server-side.
 	credHash := HashCredentialID(req.CredentialUID, s.credentialHashSecret)
 
 	// Check module is known.
@@ -73,34 +78,13 @@ func (s *ProvisionService) Provision(
 		return types.ProvisionCredentialResponse{OK: false, Known: false}, nil
 	}
 
-	// Verify operator: must be an enabled admin user.
-	if operatorUUID == "" {
-		return types.ProvisionCredentialResponse{
-			OK:     true,
-			Known:  true,
-			Status: types.ProvisionStatusUnauthorized,
-			Detail: "operator_uuid is required",
-		}, nil
-	}
-	operator, err := s.adminUsers.GetAdminUserByUUID(ctx, operatorUUID)
+	// Resolve operator identity.
+	operatorUUID, resp, err := s.resolveOperator(ctx, req)
 	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			return types.ProvisionCredentialResponse{
-				OK:     true,
-				Known:  true,
-				Status: types.ProvisionStatusUnauthorized,
-				Detail: "operator not found",
-			}, nil
-		}
-		return types.ProvisionCredentialResponse{}, fmt.Errorf("operator lookup: %w", err)
+		return types.ProvisionCredentialResponse{}, err
 	}
-	if !operator.Enabled {
-		return types.ProvisionCredentialResponse{
-			OK:     true,
-			Known:  true,
-			Status: types.ProvisionStatusUnauthorized,
-			Detail: "operator account is disabled",
-		}, nil
+	if resp != nil {
+		return *resp, nil
 	}
 
 	// Validate role.
@@ -166,6 +150,57 @@ func (s *ProvisionService) Provision(
 		MemberUUID: memberUUID,
 		Status:     types.ProvisionStatusSuccess,
 	}, nil
+}
+
+// resolveOperator determines the operator UUID from the request.
+// Returns (uuid, nil, nil) on success.
+// Returns ("", &unauthorizedResponse, nil) when the operator is not valid.
+// Returns ("", nil, err) on an internal error.
+func (s *ProvisionService) resolveOperator(
+	ctx context.Context,
+	req types.ProvisionCredentialRequest,
+) (string, *types.ProvisionCredentialResponse, error) {
+	unauthorized := func(detail string) *types.ProvisionCredentialResponse {
+		return &types.ProvisionCredentialResponse{
+			OK:     true,
+			Known:  true,
+			Status: types.ProvisionStatusUnauthorized,
+			Detail: detail,
+		}
+	}
+
+	if len(req.OperatorCredentialUID) > 0 {
+		// Preferred path (new firmware): resolve scan-1 UID to an admin user.
+		opHash := HashCredentialID(req.OperatorCredentialUID, s.credentialHashSecret)
+		operator, err := s.adminUsers.GetAdminUserByCredential(ctx, opHash)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				return "", unauthorized("operator badge not registered"), nil
+			}
+			return "", nil, fmt.Errorf("operator credential lookup: %w", err)
+		}
+		if !operator.Enabled {
+			return "", unauthorized("operator account is disabled"), nil
+		}
+		return operator.UUID, nil, nil
+	}
+
+	// Legacy path: operator_uuid supplied directly in field 1 (Kconfig firmware).
+	operatorUUID := strings.TrimSpace(req.OperatorUUID)
+	if operatorUUID == "" {
+		return "", unauthorized("operator_uuid is required"), nil
+	}
+	operator, err := s.adminUsers.GetAdminUserByUUID(ctx, operatorUUID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return "", unauthorized("operator not found"), nil
+		}
+		return "", nil, fmt.Errorf("operator lookup: %w", err)
+	}
+	if !operator.Enabled {
+		return "", unauthorized("operator account is disabled"), nil
+	}
+	return operator.UUID, nil, nil
 }
 
 // provisionDuplicateStatus maps an existing member record to the appropriate

--- a/server/internal/portunus/service/provision_service_test.go
+++ b/server/internal/portunus/service/provision_service_test.go
@@ -1,0 +1,205 @@
+package service_test
+
+// Integration tests for ProvisionService operator-resolution logic (P1-3).
+//
+// These tests verify that:
+//   - scan-1 UID (OperatorCredentialUID) resolves to an admin user (preferred path)
+//   - an unregistered scan-1 UID returns UNAUTHORIZED
+//   - a disabled admin user's badge returns UNAUTHORIZED
+//   - empty OperatorCredentialUID falls back to OperatorUUID (legacy Kconfig path)
+//   - empty both fields returns UNAUTHORIZED
+
+import (
+	"context"
+	"testing"
+
+	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/service"
+	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/store"
+	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/store/memory"
+	sqlitestore "github.com/BrandonDHaskell/Portunus/server/internal/portunus/store/sqlite"
+	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/types"
+)
+
+// testSecret is a fixed HMAC key used throughout these tests.
+var testSecret = []byte("test-secret-key-32-bytes-padding!!")
+
+// seedAdminUser creates an admin user and returns their UUID.
+func seedAdminUser(t *testing.T, adminStore *sqlitestore.AdminUserStore, username string, enabled bool) string {
+	t.Helper()
+	ctx := context.Background()
+	adminUUID := "admin-" + username
+	if err := adminStore.CreateAdminUser(ctx, adminUUID, username, "$2a$04$irrelevant", "admin"); err != nil {
+		t.Fatalf("seedAdminUser %q: CreateAdminUser: %v", username, err)
+	}
+	if !enabled {
+		if err := adminStore.SetAdminUserEnabled(ctx, adminUUID, false); err != nil {
+			t.Fatalf("seedAdminUser %q: SetAdminUserEnabled: %v", username, err)
+		}
+	}
+	return adminUUID
+}
+
+// registerAdminBadge registers rawUID as the badge for adminUUID.
+func registerAdminBadge(t *testing.T, adminStore *sqlitestore.AdminUserStore, adminUUID string, rawUID []byte) {
+	t.Helper()
+	hash := service.HashCredentialID(rawUID, testSecret)
+	if err := adminStore.RegisterAdminCredential(context.Background(), adminUUID, hash); err != nil {
+		t.Fatalf("registerAdminBadge: %v", err)
+	}
+}
+
+// newProvisionSvc builds a ProvisionService backed by real migrated SQLite.
+func newProvisionSvc(t *testing.T) (
+	*service.ProvisionService,
+	*sqlitestore.AdminUserStore,
+	store.MemberAccessStore,
+) {
+	t.Helper()
+	conn, writer := openSvcTestDB(t)
+	seedModule(t, conn, "prov-module-001")
+
+	adminStore := sqlitestore.NewAdminUserStore(conn, writer)
+	maStore := sqlitestore.NewMemberAccessStore(conn, writer)
+	roleStore := sqlitestore.NewRoleStore(conn, writer)
+
+	registry := service.NewDeviceRegistry(memory.NewDeviceStore([]string{"prov-module-001"}))
+
+	svc := service.NewProvisionService(registry, maStore, roleStore, adminStore, testSecret)
+	return svc, adminStore, maStore
+}
+
+func provisionReq(operatorUID, credUID []byte) types.ProvisionCredentialRequest {
+	return types.ProvisionCredentialRequest{
+		OperatorCredentialUID: operatorUID,
+		ModuleID:              "prov-module-001",
+		CredentialUID:         credUID,
+		RoleID:                "guest",
+	}
+}
+
+// ── scan-1 credential path ────────────────────────────────────────────────────
+
+func TestProvision_Scan1CredentialResolvesToAdmin_Success(t *testing.T) {
+	svc, adminStore, _ := newProvisionSvc(t)
+	adminUUID := seedAdminUser(t, adminStore, "alice", true)
+	operatorUID := []byte{0x04, 0xAA, 0xBB, 0xCC}
+	memberUID := []byte{0x04, 0x01, 0x02, 0x03}
+	registerAdminBadge(t, adminStore, adminUUID, operatorUID)
+
+	resp, err := svc.Provision(context.Background(), provisionReq(operatorUID, memberUID))
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if resp.Status != types.ProvisionStatusSuccess {
+		t.Errorf("expected success, got status=%q detail=%q", resp.Status, resp.Detail)
+	}
+	if resp.MemberUUID == "" {
+		t.Error("expected non-empty MemberUUID on success")
+	}
+}
+
+func TestProvision_Scan1CredentialUnregistered_Unauthorized(t *testing.T) {
+	svc, _, _ := newProvisionSvc(t)
+	// No badge registered — any scan-1 UID should be rejected.
+	operatorUID := []byte{0x04, 0xFF, 0xFF, 0xFF}
+	memberUID := []byte{0x04, 0x01, 0x02, 0x03}
+
+	resp, err := svc.Provision(context.Background(), provisionReq(operatorUID, memberUID))
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if resp.Status != types.ProvisionStatusUnauthorized {
+		t.Errorf("expected unauthorized, got status=%q detail=%q", resp.Status, resp.Detail)
+	}
+}
+
+func TestProvision_Scan1CredentialDisabledAdmin_Unauthorized(t *testing.T) {
+	svc, adminStore, _ := newProvisionSvc(t)
+	adminUUID := seedAdminUser(t, adminStore, "bob", false) // disabled
+	operatorUID := []byte{0x04, 0x11, 0x22, 0x33}
+	memberUID := []byte{0x04, 0x01, 0x02, 0x03}
+	registerAdminBadge(t, adminStore, adminUUID, operatorUID)
+
+	resp, err := svc.Provision(context.Background(), provisionReq(operatorUID, memberUID))
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if resp.Status != types.ProvisionStatusUnauthorized {
+		t.Errorf("expected unauthorized for disabled admin, got status=%q detail=%q", resp.Status, resp.Detail)
+	}
+}
+
+// ── legacy operator_uuid fallback path ───────────────────────────────────────
+
+func TestProvision_LegacyOperatorUUID_Success(t *testing.T) {
+	svc, adminStore, _ := newProvisionSvc(t)
+	adminUUID := seedAdminUser(t, adminStore, "carol", true)
+	memberUID := []byte{0x04, 0x0A, 0x0B, 0x0C}
+
+	// No operator_credential_uid — use legacy operator_uuid directly.
+	req := types.ProvisionCredentialRequest{
+		OperatorUUID:  adminUUID,
+		ModuleID:      "prov-module-001",
+		CredentialUID: memberUID,
+		RoleID:        "guest",
+	}
+	resp, err := svc.Provision(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if resp.Status != types.ProvisionStatusSuccess {
+		t.Errorf("expected success on legacy path, got status=%q detail=%q", resp.Status, resp.Detail)
+	}
+}
+
+func TestProvision_BothFieldsEmpty_Unauthorized(t *testing.T) {
+	svc, _, _ := newProvisionSvc(t)
+	req := types.ProvisionCredentialRequest{
+		ModuleID:      "prov-module-001",
+		CredentialUID: []byte{0x04, 0x01, 0x02, 0x03},
+		RoleID:        "guest",
+	}
+	resp, err := svc.Provision(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if resp.Status != types.ProvisionStatusUnauthorized {
+		t.Errorf("expected unauthorized when no operator provided, got status=%q", resp.Status)
+	}
+}
+
+// ── operator_uuid recorded in member_access.created_by_uuid ─────────────────
+
+func TestProvision_Scan1Credential_RecordsOperatorUUID(t *testing.T) {
+	conn, writer := openSvcTestDB(t)
+	seedModule(t, conn, "prov-module-001")
+
+	adminStore := sqlitestore.NewAdminUserStore(conn, writer)
+	maStore := sqlitestore.NewMemberAccessStore(conn, writer)
+	roleStore := sqlitestore.NewRoleStore(conn, writer)
+	registry := service.NewDeviceRegistry(memory.NewDeviceStore([]string{"prov-module-001"}))
+	svc := service.NewProvisionService(registry, maStore, roleStore, adminStore, testSecret)
+
+	adminUUID := seedAdminUser(t, adminStore, "dave", true)
+	operatorUID := []byte{0x04, 0xDE, 0xAD, 0xBE}
+	memberUID := []byte{0x04, 0x99, 0x88, 0x77}
+	registerAdminBadge(t, adminStore, adminUUID, operatorUID)
+
+	resp, err := svc.Provision(context.Background(), provisionReq(operatorUID, memberUID))
+	if err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	if resp.Status != types.ProvisionStatusSuccess {
+		t.Fatalf("expected success, got %q / %q", resp.Status, resp.Detail)
+	}
+
+	// Verify the member was created with the resolved admin UUID.
+	credHash := service.HashCredentialID(memberUID, testSecret)
+	member, err := maStore.GetMemberByCredential(context.Background(), credHash)
+	if err != nil {
+		t.Fatalf("GetMemberByCredential: %v", err)
+	}
+	if member.CreatedByUUID != adminUUID {
+		t.Errorf("created_by_uuid = %q, want %q", member.CreatedByUUID, adminUUID)
+	}
+}

--- a/server/internal/portunus/store/admin_user_store.go
+++ b/server/internal/portunus/store/admin_user_store.go
@@ -6,7 +6,17 @@ import (
 	"time"
 )
 
-var ErrUsernameAlreadyExists = errors.New("username already exists")
+var (
+	ErrUsernameAlreadyExists   = errors.New("username already exists")
+	ErrAdminCredentialConflict = errors.New("credential already registered to an admin user")
+)
+
+// AdminCredentialRecord represents a row in admin_user_credentials.
+type AdminCredentialRecord struct {
+	CredentialHash []byte
+	AdminUserUUID  string
+	CreatedAt      time.Time
+}
 
 // AdminUserRecord represents a row in the admin_users table.
 type AdminUserRecord struct {
@@ -54,4 +64,13 @@ type AdminUserStore interface {
 
 	// AnyAdminExists returns true if at least one admin_user row exists.
 	AnyAdminExists(ctx context.Context) (bool, error)
+
+	// RegisterAdminCredential registers a credential hash for an admin user.
+	// Returns ErrNotFound if the admin user does not exist,
+	// ErrAdminCredentialConflict if the hash is already registered.
+	RegisterAdminCredential(ctx context.Context, adminUUID string, credentialHash []byte) error
+
+	// GetAdminUserByCredential returns the admin user whose credential_hash
+	// matches, or ErrNotFound if no match exists.
+	GetAdminUserByCredential(ctx context.Context, credentialHash []byte) (*AdminUserRecord, error)
 }

--- a/server/internal/portunus/store/sqlite/admin_user_store.go
+++ b/server/internal/portunus/store/sqlite/admin_user_store.go
@@ -170,6 +170,43 @@ func (s *AdminUserStore) AnyAdminExists(ctx context.Context) (bool, error) {
 	return n > 0, nil
 }
 
+func (s *AdminUserStore) RegisterAdminCredential(ctx context.Context, adminUUID string, credentialHash []byte) error {
+	return s.writer.Do(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		var exists int
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM admin_users WHERE uuid = ?;`, adminUUID,
+		).Scan(&exists); err != nil {
+			return fmt.Errorf("RegisterAdminCredential check user: %w", err)
+		}
+		if exists == 0 {
+			return store.ErrNotFound
+		}
+
+		_, err := tx.ExecContext(ctx,
+			`INSERT INTO admin_user_credentials (credential_hash, admin_user_uuid, created_at_ms)
+			 VALUES (?, ?, ?);`,
+			credentialHash, adminUUID, time.Now().UTC().UnixMilli(),
+		)
+		if err != nil {
+			if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+				return store.ErrAdminCredentialConflict
+			}
+			return fmt.Errorf("RegisterAdminCredential insert: %w", err)
+		}
+		return nil
+	})
+}
+
+func (s *AdminUserStore) GetAdminUserByCredential(ctx context.Context, credentialHash []byte) (*store.AdminUserRecord, error) {
+	const q = `
+SELECT u.uuid, u.username, u.password_hash, COALESCE(u.role_id,'admin'), COALESCE(u.enabled,1),
+       u.must_change_pw, u.created_at_ms, u.updated_at_ms, u.last_login_at_ms
+FROM admin_users u
+JOIN admin_user_credentials c ON c.admin_user_uuid = u.uuid
+WHERE c.credential_hash = ?;`
+	return scanAdminUser(s.db.QueryRowContext(ctx, q, credentialHash))
+}
+
 // scanAdminUser scans a single *sql.Row.
 func scanAdminUser(row *sql.Row) (*store.AdminUserRecord, error) {
 	var (

--- a/server/internal/portunus/types/provision.go
+++ b/server/internal/portunus/types/provision.go
@@ -1,13 +1,17 @@
 package types
 
 // ProvisionCredentialRequest is the domain type for device-initiated provisioning.
-// CredentialUID carries the raw RFID UID bytes from the device; the server applies
-// HMAC-SHA256(secret, CredentialUID) before storing in member_access.credential_hash.
+// CredentialUID carries the scan-2 raw RFID UID bytes (new member card).
+// OperatorCredentialUID carries the scan-1 raw RFID UID bytes (operator badge).
+// When OperatorCredentialUID is non-empty the server resolves it to an admin user
+// and ignores OperatorUUID. OperatorUUID is the legacy fallback for firmware that
+// does not send scan-1 UID.
 type ProvisionCredentialRequest struct {
-	OperatorUUID  string `json:"operator_uuid"`
-	ModuleID      string `json:"module_id"`
-	CredentialUID []byte `json:"credential_uid"` // raw RFID UID bytes (1–10 bytes)
-	RoleID        string `json:"role_id"`
+	OperatorUUID          string `json:"operator_uuid"`
+	OperatorCredentialUID []byte `json:"operator_credential_uid"` // scan-1 raw UID (1–10 bytes)
+	ModuleID              string `json:"module_id"`
+	CredentialUID         []byte `json:"credential_uid"` // scan-2 raw UID (1–10 bytes)
+	RoleID                string `json:"role_id"`
 }
 
 // ProvisionStatus represents the outcome of a device-initiated provisioning request.


### PR DESCRIPTION
Proto — added bytes operator_credential_uid = 6 to ProvisionCredentialRequest; updated field 1 comment to describe legacy fallback. Updated nanopb options. Regenerated both Go and Nanopb bindings.

Server — migration 0017 (admin_user_credentials table). Extended AdminUserStore interface with RegisterAdminCredential and GetAdminUserByCredential, implemented in sqlite. Added OperatorCredentialUID []byte to types.ProvisionCredentialRequest. Updated convert.go and grpcapi/server.go to map field 6. Rewrote provision_service.go operator resolution: field 6 (credential UID) takes precedence, field 1 (UUID) is backward-compat fallback. New POST /admin/v1/admin-users/{uuid}/credential endpoint (requires admin_user.edit). admin_user_service.go gained RegisterCredential.

Firmware — event_types.h: replaced operator_uuid[37] with operator_credential_uid[10] + _len in event_provision_request_t. provisioning_fsm.cpp: scan-1 stores UID in m_operator_cred, scan-2 populates field 6 (operator UID) and field 5 (member UID). server_comm.cpp: encodes field 6. Kconfig.projbuild: removed CONFIG_PORTUNUS_OPERATOR_UUID. Updated FSM header and doc comments.

Tests — 6 new tests in provision_service_test.go: scan-1 success, unregistered badge → UNAUTHORIZED, disabled admin → UNAUTHORIZED, legacy UUID fallback, both empty → UNAUTHORIZED, created_by_uuid records the resolved operator.

Note on proto:check: will show drift locally (local protoc-gen-go-grpc is v1.6.1 vs CI's v1.6.2, plus uncommitted generated files). 