### PR TITLE
Taskfile, env files, .gitignore, and the CI smoke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # ── Secrets & environment ──
 .env*
-!.env*.example
+# Re-include the committed, non-secret server profiles. .env and .env.prod stay
+# ignored. (Patterns without a slash match at any depth, so server/.env.local
+# and server/.env.ci are re-included.)
+!.env.local
+!.env.ci
 
 # ── TLS material ──
 certs/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -133,10 +133,17 @@ tasks:
     cmds:
       - go build -o bin/portunus-server-linux-arm64 ./cmd/portunus-server
 
-  run:server:dev:
-    desc: Run the server with the dev profile (server/.env.dev)
+  run:server:local:
+    desc: Run the server with the local profile (server/.env.local)
     dir: "{{.SERVER_DIR}}"
-    dotenv: ['.env.dev']
+    dotenv: ['.env.local']
+    cmds:
+      - go run ./cmd/portunus-server
+
+  run:server:ci:
+    desc: Run the server with the ci profile (server/.env.ci — TLS + gRPC, in-memory DB)
+    dir: "{{.SERVER_DIR}}"
+    dotenv: ['.env.ci']
     cmds:
       - go run ./cmd/portunus-server
 
@@ -377,12 +384,37 @@ tasks:
     cmds:
       - "{{.IDF_PYTHON}} scripts/proto_gen.py --check"
 
+  ci:server:smoke:
+    desc: Boot the ci profile and verify HTTPS + gRPC TLS come up (Linux/macOS)
+    dir: "{{.SERVER_DIR}}"
+    cmds:
+      - |
+        set -euo pipefail
+        go build -o bin/portunus-server ./cmd/portunus-server
+        set -a; . ./.env.ci; set +a
+        ./bin/portunus-server & SRV=$!
+        trap 'kill $SRV 2>/dev/null || true' EXIT
+        code=""
+        for _ in $(seq 1 30); do
+          code=$(curl -ksS -o /dev/null -w '%{http_code}' https://127.0.0.1:8443/admin/ui/login || true)
+          [ "$code" = "200" ] && break
+          sleep 0.2
+        done
+        [ "$code" = "200" ] || { echo "HTTPS smoke FAILED (last code: ${code:-none})"; exit 1; }
+        echo "HTTPS OK: /admin/ui/login -> 200 over TLS"
+        if echo | openssl s_client -connect 127.0.0.1:50051 -alpn h2 2>/dev/null | grep -q "BEGIN CERTIFICATE"; then
+          echo "gRPC TLS OK: certificate presented on :50051"
+        else
+          echo "gRPC TLS smoke FAILED"; exit 1
+        fi
+
   ci:server:
-    desc: Full server CI check (vet, format, test with race detector)
+    desc: Full server CI check (vet, format, test with race detector, boot smoke)
     cmds:
       - task: vet:server
       - task: fmt:server
       - task: test:server:race
+      - task: ci:server:smoke
 
   ci:all:
     desc: Full CI — server checks + proto drift + firmware compile

--- a/server/.env.ci
+++ b/server/.env.ci
@@ -1,0 +1,10 @@
+# CI profile — exercises the full TLS + gRPC + serialization boot path with no
+# committed secret material. Committed on purpose: contains no secrets.
+PORTUNUS_ENV=ci
+PORTUNUS_HTTP_ADDR=:8443
+PORTUNUS_GRPC_ADDR=:50051
+PORTUNUS_DB_PATH=:memory:
+
+# TLS cert/key intentionally unset: the ci profile generates an ephemeral
+# self-signed cert in-process (config.EphemeralCert), so CI runs the same TLS
+# handshake path as prod with nothing on disk and nothing to rotate.

--- a/server/.env.local
+++ b/server/.env.local
@@ -1,0 +1,9 @@
+# Local development profile — fast iteration loop.
+# Committed on purpose: contains no secrets.
+PORTUNUS_ENV=local
+PORTUNUS_HTTP_ADDR=:8080
+PORTUNUS_DB_PATH=./data/portunus.db
+
+# Plain HTTP and gRPC off by default for speed. To exercise TLS locally, run the
+# prod profile against localhost (the mirror loop) or run the ci profile.
+# HMAC and credential-hash secrets are optional under local.


### PR DESCRIPTION
Stage 3 is complete. All acceptance criteria met:

task run:server:local and task run:server:ci are wired to their respective env files
task ci:server:smoke builds the binary, gets 200 over HTTPS, confirms a cert on the gRPC port, and exits 0
task ci:server runs the smoke as its final step
server/.env.local and server/.env.ci are tracked (git check-ignore prints nothing for them)
.env and server/.env.prod remain ignored
run:server:dev is gone