### PR TITLE
added back editable members from Admin UI

### DIFF
--- a/server/internal/db/migrations/0028_seed_member_edit_permission.sql
+++ b/server/internal/db/migrations/0028_seed_member_edit_permission.sql
@@ -1,0 +1,12 @@
+-- 0028: seed member.edit permission for admin and operator roles.
+--
+-- PR #61 (feat/refactor-admin-member-separation) dropped MemberAssignRole but
+-- never added a replacement edit permission.  This seeds member.edit so that
+-- admins and operators can update a member's policy fields (expires_at,
+-- inactivity_limit_days) after activation.
+--
+-- INSERT OR IGNORE is idempotent: safe to re-apply.
+
+INSERT OR IGNORE INTO role_permissions (role_id, permission, granted_at_ms) VALUES
+  ('admin',    'member.edit', CAST(strftime('%s','now') AS INTEGER) * 1000),
+  ('operator', 'member.edit', CAST(strftime('%s','now') AS INTEGER) * 1000);

--- a/server/internal/httpapi/templates/members_detail.html
+++ b/server/internal/httpapi/templates/members_detail.html
@@ -2,7 +2,12 @@
 {{define "content"}}
 <div class="page-header">
   <h1>Member Detail</h1>
-  <a class="btn btn-secondary" href="/admin/ui/members">← Members</a>
+  <div style="display:flex;gap:.5rem">
+    {{with .Member}}
+    <a class="btn btn-secondary" href="/admin/ui/members/{{.UUID}}/edit">Edit Policy</a>
+    {{end}}
+    <a class="btn btn-secondary" href="/admin/ui/members">← Members</a>
+  </div>
 </div>
 
 {{with .Member}}

--- a/server/internal/httpapi/templates/members_edit.html
+++ b/server/internal/httpapi/templates/members_edit.html
@@ -1,0 +1,54 @@
+{{define "title"}}Edit Member — Portunus Admin{{end}}
+{{define "content"}}
+<div class="page-header">
+  <h1>Edit Member</h1>
+  <a class="btn btn-secondary" href="/admin/ui/members/{{.Member.UUID}}">← Back to Member</a>
+</div>
+
+{{with .Member}}
+<div class="card" style="max-width:520px">
+  <div class="form-group">
+    <label>UUID</label>
+    <input type="text" class="font-mono" value="{{.UUID}}" readonly>
+  </div>
+  <div class="form-group">
+    <label>Status</label>
+    <div style="margin-top:.25rem">
+      {{if eq .Status "active"}}
+        {{if .Enabled}}<span class="badge badge-green">Active</span>
+        {{else}}<span class="badge badge-yellow">Disabled</span>{{end}}
+      {{else if eq .Status "expired"}}
+        <span class="badge badge-red">Expired</span>
+      {{else}}
+        <span class="badge">{{.Status}}</span>
+      {{end}}
+    </div>
+  </div>
+
+  <form method="POST" action="/admin/ui/members/{{.UUID}}/edit" style="margin-top:1.5rem">
+    <h2 style="margin-top:0">Access Policy</h2>
+    <div class="form-group">
+      <label for="expires_at">Hard Expiry (leave blank for no deadline)</label>
+      <input id="expires_at" name="expires_at" type="date"
+        value="{{if .ExpiresAt}}{{slice .ExpiresAt 0 10}}{{end}}">
+    </div>
+    <div class="form-group">
+      <label for="inactivity_limit_days">Inactivity Limit (days, leave blank to disable)</label>
+      <select id="inactivity_limit_days" name="inactivity_limit_days">
+        <option value="">— None —</option>
+        <option value="7"  {{if eq (derefInt .InactivityLimitDays) 7}}selected{{end}}>7 days</option>
+        <option value="14" {{if eq (derefInt .InactivityLimitDays) 14}}selected{{end}}>14 days</option>
+        <option value="30" {{if eq (derefInt .InactivityLimitDays) 30}}selected{{end}}>30 days</option>
+        <option value="90" {{if eq (derefInt .InactivityLimitDays) 90}}selected{{end}}>90 days</option>
+        <option value="180" {{if eq (derefInt .InactivityLimitDays) 180}}selected{{end}}>180 days</option>
+        <option value="365" {{if eq (derefInt .InactivityLimitDays) 365}}selected{{end}}>365 days</option>
+      </select>
+    </div>
+    <div class="actions">
+      <button class="btn btn-primary" type="submit">Save Changes</button>
+      <a class="btn btn-secondary" href="/admin/ui/members/{{.UUID}}">Cancel</a>
+    </div>
+  </form>
+</div>
+{{end}}
+{{end}}

--- a/server/internal/httpapi/templates/members_list.html
+++ b/server/internal/httpapi/templates/members_list.html
@@ -11,7 +11,6 @@
   <thead>
     <tr>
       <th>UUID</th>
-      <th>Role</th>
       <th>Status</th>
       <th>Provisioning</th>
       <th>Credential</th>
@@ -23,7 +22,6 @@
   {{range .Members}}
     <tr>
       <td class="font-mono" style="font-size:.8rem">{{.UUID}}</td>
-      <td><span class="badge badge-blue">{{.RoleID}}</span></td>
       <td>
         {{if eq .Status "active"}}
           {{if .Enabled}}<span class="badge badge-green">Active</span>
@@ -49,12 +47,13 @@
         {{if .CredentialHash}}{{.CredentialHash}}{{else}}<em>none</em>{{end}}
       </td>
       <td class="text-muted" style="font-size:.85rem">{{.CreatedAt}}</td>
-      <td>
+      <td style="display:flex;gap:.4rem">
         <a class="btn btn-secondary btn-sm" href="/admin/ui/members/{{.UUID}}">View</a>
+        <a class="btn btn-secondary btn-sm" href="/admin/ui/members/{{.UUID}}/edit">Edit</a>
       </td>
     </tr>
   {{else}}
-    <tr><td colspan="7" class="text-muted" style="text-align:center;padding:2rem">No members found.</td></tr>
+    <tr><td colspan="6" class="text-muted" style="text-align:center;padding:2rem">No members found.</td></tr>
   {{end}}
   </tbody>
 </table>

--- a/server/internal/httpapi/ui_members.go
+++ b/server/internal/httpapi/ui_members.go
@@ -256,6 +256,73 @@ func (s *Server) handleUIMembersApprove(w http.ResponseWriter, r *http.Request) 
 	flashRedirect(w, r, "/admin/ui/members/"+memberUUID, "Member approved and activated.", "success")
 }
 
+// handleUIMembersEdit serves GET /admin/ui/members/{member_uuid}/edit.
+func (s *Server) handleUIMembersEdit(w http.ResponseWriter, r *http.Request) {
+	memberUUID := r.PathValue("member_uuid")
+	d := newUIPageData(r, "members")
+
+	rec, err := s.memberAccessService.GetMember(r.Context(), memberUUID)
+	if err != nil {
+		if errors.Is(err, service.ErrMemberNotFound) {
+			http.NotFound(w, r)
+			return
+		}
+		s.logger.Printf("ui get member for edit: %v", err)
+		flashRedirect(w, r, "/admin/ui/members", "Failed to load member.", "error")
+		return
+	}
+	info := memberRecordToInfo(rec)
+	d.Member = &info
+
+	render.render(w, "members_edit", d)
+}
+
+// handleUIMembersUpdate handles POST /admin/ui/members/{member_uuid}/edit.
+func (s *Server) handleUIMembersUpdate(w http.ResponseWriter, r *http.Request) {
+	memberUUID := r.PathValue("member_uuid")
+	if err := r.ParseForm(); err != nil {
+		flashRedirect(w, r, "/admin/ui/members/"+memberUUID+"/edit", "Invalid form submission.", "error")
+		return
+	}
+
+	expiresAtStr := r.FormValue("expires_at")
+	inactivityStr := r.FormValue("inactivity_limit_days")
+
+	var expiresAt *time.Time
+	if expiresAtStr != "" {
+		t, err := time.Parse("2006-01-02", expiresAtStr)
+		if err != nil {
+			flashRedirect(w, r, "/admin/ui/members/"+memberUUID+"/edit", "Invalid expiry date format (use YYYY-MM-DD).", "error")
+			return
+		}
+		u := t.UTC()
+		expiresAt = &u
+	}
+
+	var inactivityDays *int
+	if inactivityStr != "" {
+		var n int
+		if _, err := parseIntFormValue(inactivityStr, &n); err != nil || n < 1 {
+			flashRedirect(w, r, "/admin/ui/members/"+memberUUID+"/edit", "Inactivity limit must be a positive number.", "error")
+			return
+		}
+		inactivityDays = &n
+	}
+
+	if err := s.memberAccessService.UpdateMemberPolicy(r.Context(), memberUUID, expiresAt, inactivityDays); err != nil {
+		if errors.Is(err, service.ErrMemberNotFound) {
+			http.NotFound(w, r)
+			return
+		}
+		s.logger.Printf("ui update member policy %s: %v", memberUUID, err)
+		flashRedirect(w, r, "/admin/ui/members/"+memberUUID+"/edit", "Failed to update member.", "error")
+		return
+	}
+
+	s.logger.Printf("admin ui: updated policy for member %s", memberUUID)
+	flashRedirect(w, r, "/admin/ui/members/"+memberUUID, "Member policy updated.", "success")
+}
+
 // handleUIMembersDisable handles POST /admin/ui/members/{member_uuid}/disable.
 func (s *Server) handleUIMembersDisable(w http.ResponseWriter, r *http.Request) {
 	memberUUID := r.PathValue("member_uuid")
@@ -417,6 +484,10 @@ func (s *Server) uiMemberRoutes(mux *http.ServeMux) {
 	// Member detail + actions
 	mux.HandleFunc("GET /admin/ui/members/{member_uuid}",
 		perm(permissions.MemberView, s.handleUIMembersDetail))
+	mux.HandleFunc("GET /admin/ui/members/{member_uuid}/edit",
+		perm(permissions.MemberEdit, s.handleUIMembersEdit))
+	mux.HandleFunc("POST /admin/ui/members/{member_uuid}/edit",
+		perm(permissions.MemberEdit, s.handleUIMembersUpdate))
 	mux.HandleFunc("POST /admin/ui/members/{member_uuid}/approve",
 		perm(permissions.MemberEnroll, s.handleUIMembersApprove))
 	mux.HandleFunc("POST /admin/ui/members/{member_uuid}/credential",

--- a/server/internal/portunus/permissions/permissions.go
+++ b/server/internal/portunus/permissions/permissions.go
@@ -34,6 +34,7 @@ const (
 	MemberEnroll  = "member.enroll"
 	MemberList    = "member.list"
 	MemberView    = "member.view"
+	MemberEdit    = "member.edit"
 	MemberDisable = "member.disable"
 	MemberArchive = "member.archive"
 
@@ -58,7 +59,7 @@ func All() []string {
 		DoorList, DoorRegister, DoorDelete,
 		AdminUserCreate, AdminUserList, AdminUserEdit, AdminUserDisable,
 		RoleList, RoleCreate, RoleEdit, RoleDelete, RoleAssignPermission,
-		MemberEnroll, MemberList, MemberView, MemberDisable, MemberArchive,
+		MemberEnroll, MemberList, MemberView, MemberEdit, MemberDisable, MemberArchive,
 		ModuleAuthGrantHeld, ModuleAuthGrantAny, ModuleAuthRevokeHeld, ModuleAuthRevokeAny, ModuleAuthList,
 		AuditLogList,
 	}

--- a/server/internal/portunus/service/member_access_service.go
+++ b/server/internal/portunus/service/member_access_service.go
@@ -184,6 +184,21 @@ func (s *MemberAccessService) ListPendingAuthorizations(ctx context.Context) ([]
 	return s.memberStore.ListPendingAuthorizations(ctx)
 }
 
+// UpdateMemberPolicy updates expires_at and inactivity_limit_days for any
+// non-archived member. Pass nil to clear a field.
+func (s *MemberAccessService) UpdateMemberPolicy(ctx context.Context, memberUUID string, expiresAt *time.Time, inactivityLimitDays *int) error {
+	if strings.TrimSpace(memberUUID) == "" {
+		return ErrMemberUUIDRequired
+	}
+	if err := s.memberStore.UpdateMemberPolicy(ctx, memberUUID, expiresAt, inactivityLimitDays); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return ErrMemberNotFound
+		}
+		return fmt.Errorf("update member policy: %w", err)
+	}
+	return nil
+}
+
 // ApprovePending activates a pending_authorization member.
 // inactivityLimitDays is required — the admin must explicitly choose a window.
 // expiresAt is optional; nil means no hard deadline.

--- a/server/internal/portunus/store/member_access_store.go
+++ b/server/internal/portunus/store/member_access_store.go
@@ -111,6 +111,11 @@ type MemberAccessStore interface {
 	ApprovePending(ctx context.Context, uuid, approvedByUUID string,
 		expiresAt *time.Time, inactivityLimitDays *int) error
 
+	// UpdateMemberPolicy updates the policy fields of a member: expires_at and
+	// inactivity_limit_days. Pass nil to clear a field. Returns ErrNotFound if
+	// the member does not exist.
+	UpdateMemberPolicy(ctx context.Context, uuid string, expiresAt *time.Time, inactivityLimitDays *int) error
+
 	// ArchiveStalePending transitions pending_authorization rows whose
 	// created_at_ms + ttlDays*86400000 < now to status='archived'. Returns the
 	// number of rows affected.

--- a/server/internal/portunus/store/sqlite/member_access_store.go
+++ b/server/internal/portunus/store/sqlite/member_access_store.go
@@ -251,6 +251,23 @@ WHERE uuid = ?;
 	})
 }
 
+func (s *MemberAccessStore) UpdateMemberPolicy(ctx context.Context, uuid string, expiresAt *time.Time, inactivityLimitDays *int) error {
+	var expiresAtMs *int64
+	if expiresAt != nil {
+		ms := expiresAt.UTC().UnixMilli()
+		expiresAtMs = &ms
+	}
+	return s.writer.Do(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx,
+			`UPDATE member_access SET expires_at_ms = ?, inactivity_limit_days = ? WHERE uuid = ?;`,
+			expiresAtMs, inactivityLimitDays, uuid)
+		if err != nil {
+			return fmt.Errorf("UpdateMemberPolicy: %w", err)
+		}
+		return requireOneRow(res, "UpdateMemberPolicy")
+	})
+}
+
 func (s *MemberAccessStore) ArchiveStalePending(ctx context.Context, now time.Time, ttlDays int) (int64, error) {
 	nowMs := now.UTC().UnixMilli()
 	ttlMs := int64(ttlDays) * 86400000


### PR DESCRIPTION
Root cause: PR #61 (feat/refactor-admin-member-separation) dropped the old MemberAssignRole permission and its handler, which was the only "edit" path for members. The refactor never replaced it with a member.edit permission or any mechanism to update policy fields (expires_at, inactivity_limit_days) post-activation. The result: no constant, no store method, no service method, no route, no template.

and

No "Edit" link — Actions column only has "View", so members can't be edited directly from the list.
Stale "Role" column referencing .RoleID — MemberInfo has no RoleID field (members have been roleless since PR #61), so this renders blank for every row.