### PR TITLE
addedd audit record capture to users

### DIFF
--- a/access_module/components/portunus_proto/portunus/v1/portunus.pb.h
+++ b/access_module/components/portunus_proto/portunus/v1/portunus.pb.h
@@ -99,9 +99,9 @@ typedef struct _portunus_v1_AccessResponse {
         | "credential_not_found"
         | "member_expired" | "member_suspended" | "member_archived"
         | "member_disabled"
-        | "module_not_authorized"
+        | "credential_not_authorized"
         | "authorization_revoked" | "authorization_expired"
- Longest value: "invalid_credential_format" (25 chars).
+ Longest value: "invalid_credential_format" | "credential_not_authorized" (25 chars).
  Nanopb max_size:33 (32 chars + NUL) — never add a reason longer than 32.
  Note: "member_lookup_error" and "service_misconfigured" appear in the
  audit log only; the service returns an error to the transport in those

--- a/proto/portunus/v1/portunus.proto
+++ b/proto/portunus/v1/portunus.proto
@@ -131,9 +131,9 @@ message AccessResponse {
   //        | "credential_not_found"
   //        | "member_expired" | "member_suspended" | "member_archived"
   //        | "member_disabled"
-  //        | "module_not_authorized"
+  //        | "credential_not_authorized"
   //        | "authorization_revoked" | "authorization_expired"
-  // Longest value: "invalid_credential_format" (25 chars).
+  // Longest value: "invalid_credential_format" | "credential_not_authorized" (25 chars).
   // Nanopb max_size:33 (32 chars + NUL) — never add a reason longer than 32.
   // Note: "member_lookup_error" and "service_misconfigured" appear in the
   // audit log only; the service returns an error to the transport in those

--- a/server/api/portunus/v1/portunus.pb.go
+++ b/server/api/portunus/v1/portunus.pb.go
@@ -399,10 +399,10 @@ type AccessResponse struct {
 	//	| "credential_not_found"
 	//	| "member_expired" | "member_suspended" | "member_archived"
 	//	| "member_disabled"
-	//	| "module_not_authorized"
+	//	| "credential_not_authorized"
 	//	| "authorization_revoked" | "authorization_expired"
 	//
-	// Longest value: "invalid_credential_format" (25 chars).
+	// Longest value: "invalid_credential_format" | "credential_not_authorized" (25 chars).
 	// Nanopb max_size:33 (32 chars + NUL) — never add a reason longer than 32.
 	// Note: "member_lookup_error" and "service_misconfigured" appear in the
 	// audit log only; the service returns an error to the transport in those

--- a/server/cmd/portunus-server/main.go
+++ b/server/cmd/portunus-server/main.go
@@ -124,7 +124,7 @@ func main() {
 	}
 
 	// Admin user and role management services.
-	adminUserSvc := service.NewAdminUserService(adminUserStore, roleStore)
+	adminUserSvc := service.NewAdminUserService(adminUserStore, roleStore, auditStore)
 	roleSvc := service.NewRoleService(roleStore)
 
 	// Acquire the serving certificate once. prod loads it from PEM files; ci

--- a/server/internal/httpapi/ui_users.go
+++ b/server/internal/httpapi/ui_users.go
@@ -53,7 +53,8 @@ func (s *Server) handleUIUsersCreate(w http.ResponseWriter, r *http.Request) {
 	password := r.FormValue("password")
 	roleID := r.FormValue("role_id")
 
-	_, err := s.adminUserService.CreateUser(r.Context(), username, password, roleID)
+	sess := sessionFromContext(r.Context())
+	_, err := s.adminUserService.CreateUser(r.Context(), sess.AdminUUID, username, password, roleID)
 	if err != nil {
 		if errors.Is(err, store.ErrUsernameAlreadyExists) {
 			d := newUIPageData(r, "users")
@@ -134,7 +135,8 @@ func (s *Server) handleUIUsersSetExpiry(w http.ResponseWriter, r *http.Request) 
 		expiresAt = &eod
 	}
 
-	if err := s.adminUserService.SetExpiry(r.Context(), uuid, expiresAt); err != nil {
+	sess := sessionFromContext(r.Context())
+	if err := s.adminUserService.SetExpiry(r.Context(), sess.AdminUUID, uuid, expiresAt); err != nil {
 		if errors.Is(err, service.ErrAdminUserNotFound) {
 			http.NotFound(w, r)
 			return
@@ -169,7 +171,8 @@ func (s *Server) handleUIUsersSetMemberLink(w http.ResponseWriter, r *http.Reque
 		memberUUID = &raw
 	}
 
-	if err := s.adminUserService.SetMemberLink(r.Context(), uuid, memberUUID); err != nil {
+	sess := sessionFromContext(r.Context())
+	if err := s.adminUserService.SetMemberLink(r.Context(), sess.AdminUUID, uuid, memberUUID); err != nil {
 		if errors.Is(err, service.ErrAdminUserNotFound) {
 			http.NotFound(w, r)
 			return
@@ -199,7 +202,8 @@ func (s *Server) handleUIUsersAssignRole(w http.ResponseWriter, r *http.Request)
 	}
 
 	roleID := r.FormValue("role_id")
-	if err := s.adminUserService.AssignRole(r.Context(), uuid, roleID); err != nil {
+	sess := sessionFromContext(r.Context())
+	if err := s.adminUserService.AssignRole(r.Context(), sess.AdminUUID, uuid, roleID); err != nil {
 		if errors.Is(err, service.ErrAdminUserNotFound) {
 			http.NotFound(w, r)
 			return
@@ -247,8 +251,9 @@ func (s *Server) handleUIUsersDisable(w http.ResponseWriter, r *http.Request) {
 // handleUIUsersEnable handles POST /admin/ui/users/{uuid}/enable.
 func (s *Server) handleUIUsersEnable(w http.ResponseWriter, r *http.Request) {
 	uuid := r.PathValue("uuid")
+	sess := sessionFromContext(r.Context())
 
-	if err := s.adminUserService.SetEnabled(r.Context(), uuid, "", true); err != nil {
+	if err := s.adminUserService.SetEnabled(r.Context(), uuid, sess.AdminUUID, true); err != nil {
 		if errors.Is(err, service.ErrAdminUserNotFound) {
 			http.NotFound(w, r)
 			return

--- a/server/internal/portunus/service/access_service.go
+++ b/server/internal/portunus/service/access_service.go
@@ -282,7 +282,7 @@ func (s *AccessService) decideMemberAccess(
 	auth, err := s.moduleAuthStore.GetAuthorization(ctx, member.UUID, moduleID)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
-			return false, "module_not_authorized", "", nil
+			return false, "credential_not_authorized", "", nil
 		}
 		return false, "", "", err
 	}

--- a/server/internal/portunus/service/access_service_member_test.go
+++ b/server/internal/portunus/service/access_service_member_test.go
@@ -197,8 +197,8 @@ func TestAccessService_MemberPath_NoAuthorization(t *testing.T) {
 	if resp.Granted {
 		t.Error("expected granted=false when no authorization exists")
 	}
-	if resp.Reason != "module_not_authorized" {
-		t.Errorf("expected reason=module_not_authorized, got %q", resp.Reason)
+	if resp.Reason != "credential_not_authorized" {
+		t.Errorf("expected reason=credential_not_authorized, got %q", resp.Reason)
 	}
 }
 
@@ -238,10 +238,10 @@ func TestAccessService_MemberPath_RevokedAuthorization(t *testing.T) {
 	if resp.Granted {
 		t.Error("expected granted=false for revoked authorization")
 	}
-	// After revoke the row exists but revoked_at_ms is set; GetAuthorization
-	// returns the most recent row. The decideMemberAccess path checks RevokedAt.
-	if resp.Reason != "authorization_revoked" && resp.Reason != "module_not_authorized" {
-		t.Errorf("unexpected reason %q", resp.Reason)
+	// After revoke the row still exists with revoked_at_ms set; GetAuthorization
+	// returns it and decideMemberAccess fires the RevokedAt branch.
+	if resp.Reason != "authorization_revoked" {
+		t.Errorf("expected reason=authorization_revoked, got %q", resp.Reason)
 	}
 }
 
@@ -681,13 +681,13 @@ func TestAccess_FirmwareEnrolledCredential_IsGranted(t *testing.T) {
 // guard required by P1-1.  It constructs the service the same way main.go does
 // (both member-access and module-auth stores wired) and asserts that a member
 // whose credential IS enrolled but has NO module authorization is denied with
-// reason "module_not_authorized".
+// reason "credential_not_authorized".
 //
 // If moduleAuthStore were ever accidentally removed from the wiring, the service
 // would error out (branch 3/4 hard-error path), not silently grant.  If the
 // member-access path were accidentally replaced with a credential-only path, this
 // test would catch the regression: "credential_allowed" would appear instead of
-// "module_not_authorized".
+// "credential_not_authorized".
 func TestAccessService_FailOpen_UnauthorizedModuleIsDenied(t *testing.T) {
 	ctx := context.Background()
 	dbConn, writer := openSvcTestDB(t)
@@ -724,7 +724,7 @@ func TestAccessService_FailOpen_UnauthorizedModuleIsDenied(t *testing.T) {
 	if resp.Granted {
 		t.Error("enrolled member with no module authorization must not be granted")
 	}
-	if resp.Reason != "module_not_authorized" {
-		t.Errorf("expected reason=module_not_authorized, got %q — wiring regression?", resp.Reason)
+	if resp.Reason != "credential_not_authorized" {
+		t.Errorf("expected reason=credential_not_authorized, got %q — wiring regression?", resp.Reason)
 	}
 }

--- a/server/internal/portunus/service/access_service_test.go
+++ b/server/internal/portunus/service/access_service_test.go
@@ -279,7 +279,7 @@ func TestAccessReasonCodes_FitNanopbBound(t *testing.T) {
 		"member_suspended",
 		"member_archived",
 		"member_disabled",
-		"module_not_authorized",
+		"credential_not_authorized",
 		"authorization_revoked",
 		"authorization_expired",
 		"credential_allowed",

--- a/server/internal/portunus/service/admin_user_service.go
+++ b/server/internal/portunus/service/admin_user_service.go
@@ -35,18 +35,19 @@ type AdminUserInfo struct {
 // AdminUserService manages server operator accounts (create, list, edit,
 // disable, assign role).  Auth operations (login/session) stay in AuthService.
 type AdminUserService struct {
-	users store.AdminUserStore
-	roles store.RoleStore
+	users      store.AdminUserStore
+	roles      store.RoleStore
+	auditStore store.AuditStore // may be nil; writes are best-effort
 }
 
-func NewAdminUserService(users store.AdminUserStore, roles store.RoleStore) *AdminUserService {
-	return &AdminUserService{users: users, roles: roles}
+func NewAdminUserService(users store.AdminUserStore, roles store.RoleStore, audit store.AuditStore) *AdminUserService {
+	return &AdminUserService{users: users, roles: roles, auditStore: audit}
 }
 
 // CreateUser creates a new admin user with the given role.
 // The new account starts with must_change_pw = 1 so the operator must set a
 // personal password on first login.
-func (s *AdminUserService) CreateUser(ctx context.Context, username, password, roleID string) (*AdminUserInfo, error) {
+func (s *AdminUserService) CreateUser(ctx context.Context, callerUUID, username, password, roleID string) (*AdminUserInfo, error) {
 	username = strings.TrimSpace(username)
 	if username == "" {
 		return nil, fmt.Errorf("username is required")
@@ -81,6 +82,7 @@ func (s *AdminUserService) CreateUser(ctx context.Context, username, password, r
 		return nil, err
 	}
 
+	s.recordAudit(ctx, callerUUID, "admin_user.created", uuid, "success", username+":"+roleID)
 	return &AdminUserInfo{
 		UUID:         uuid,
 		Username:     username,
@@ -147,11 +149,16 @@ func (s *AdminUserService) SetEnabled(ctx context.Context, uuid, callerUUID stri
 		}
 		return fmt.Errorf("set enabled: %w", err)
 	}
+	action := "admin_user.enabled"
+	if !enabled {
+		action = "admin_user.disabled"
+	}
+	s.recordAudit(ctx, callerUUID, action, uuid, "success", "")
 	return nil
 }
 
 // AssignRole assigns a role to an admin user.
-func (s *AdminUserService) AssignRole(ctx context.Context, uuid, roleID string) error {
+func (s *AdminUserService) AssignRole(ctx context.Context, callerUUID, uuid, roleID string) error {
 	roleID = strings.TrimSpace(roleID)
 	if roleID == "" {
 		return fmt.Errorf("role_id is required")
@@ -188,13 +195,14 @@ func (s *AdminUserService) AssignRole(ctx context.Context, uuid, roleID string) 
 		}
 		return fmt.Errorf("assign role: %w", err)
 	}
+	s.recordAudit(ctx, callerUUID, "admin_user.role_assigned", uuid, "success", roleID)
 	return nil
 }
 
 // SetExpiry sets or clears the account expiry for an admin user.
 // Setting any expiry on the last qualifying admin (enabled + not expired) fails
 // with ErrLastAdmin.
-func (s *AdminUserService) SetExpiry(ctx context.Context, uuid string, expiresAt *time.Time) error {
+func (s *AdminUserService) SetExpiry(ctx context.Context, callerUUID, uuid string, expiresAt *time.Time) error {
 	if expiresAt != nil {
 		target, err := s.users.GetAdminUserByUUID(ctx, uuid)
 		if err != nil {
@@ -219,12 +227,17 @@ func (s *AdminUserService) SetExpiry(ctx context.Context, uuid string, expiresAt
 		}
 		return fmt.Errorf("set expiry: %w", err)
 	}
+	details := "cleared"
+	if expiresAt != nil {
+		details = expiresAt.Format(time.RFC3339)
+	}
+	s.recordAudit(ctx, callerUUID, "admin_user.expiry_set", uuid, "success", details)
 	return nil
 }
 
 // SetMemberLink links or unlinks a member_access row to an admin account.
 // Returns ErrMemberAlreadyLinked if the member is already linked to another account.
-func (s *AdminUserService) SetMemberLink(ctx context.Context, uuid string, memberUUID *string) error {
+func (s *AdminUserService) SetMemberLink(ctx context.Context, callerUUID, uuid string, memberUUID *string) error {
 	if err := s.users.SetAdminUserMemberLink(ctx, uuid, memberUUID); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return ErrAdminUserNotFound
@@ -234,7 +247,33 @@ func (s *AdminUserService) SetMemberLink(ctx context.Context, uuid string, membe
 		}
 		return fmt.Errorf("set member link: %w", err)
 	}
+	details := "cleared"
+	if memberUUID != nil {
+		details = *memberUUID
+	}
+	s.recordAudit(ctx, callerUUID, "admin_user.member_linked", uuid, "success", details)
 	return nil
+}
+
+func (s *AdminUserService) recordAudit(ctx context.Context, actorUUID, action, resourceID, result, details string) {
+	if s.auditStore == nil {
+		return
+	}
+	e := store.AuditEntry{
+		ActorUUID:    actorUUID,
+		ActorType:    store.ActorTypeAdmin,
+		Action:       action,
+		ResourceType: "admin_user",
+		ResourceID:   resourceID,
+		Result:       result,
+		Details:      details,
+	}
+	if actorUUID == "" {
+		e.ActorType = store.ActorTypeSystem
+	}
+	if err := s.auditStore.RecordAuditEntry(ctx, e); err != nil {
+		_ = err
+	}
 }
 
 func adminUserRecordToInfo(r *store.AdminUserRecord) AdminUserInfo {

--- a/server/internal/portunus/service/admin_user_service_test.go
+++ b/server/internal/portunus/service/admin_user_service_test.go
@@ -12,12 +12,13 @@ import (
 )
 
 // newAdminUserSvc wires AdminUserService against in-memory SQLite with real migrations.
-func newAdminUserSvc(t *testing.T) (*service.AdminUserService, store.AdminUserStore, store.RoleStore) {
+func newAdminUserSvc(t *testing.T) (*service.AdminUserService, store.AdminUserStore, store.RoleStore, store.AuditStore) {
 	t.Helper()
 	dbConn, writer := openSvcTestDB(t)
 	us := sqlitestore.NewAdminUserStore(dbConn, writer)
 	rs := sqlitestore.NewRoleStore(dbConn, writer)
-	return service.NewAdminUserService(us, rs), us, rs
+	as := sqlitestore.NewAuditStore(dbConn, writer)
+	return service.NewAdminUserService(us, rs, as), us, rs, as
 }
 
 // seedAdminUser inserts a minimal admin_users row via the store, bypassing bcrypt.
@@ -34,10 +35,26 @@ func seedAdminUser(t *testing.T, us store.AdminUserStore, uuid, roleID string, e
 	}
 }
 
+// requireAuditEntry asserts that exactly one audit entry matching action and
+// resourceID exists in the audit log.
+func requireAuditEntry(t *testing.T, as store.AuditStore, action, resourceID string) {
+	t.Helper()
+	entries, err := as.ListAuditEntries(context.Background(), 50)
+	if err != nil {
+		t.Fatalf("ListAuditEntries: %v", err)
+	}
+	for _, e := range entries {
+		if e.Action == action && e.ResourceID == resourceID {
+			return
+		}
+	}
+	t.Errorf("no audit entry found with action=%q resourceID=%q (got %d entries)", action, resourceID, len(entries))
+}
+
 // ── SetEnabled ────────────────────────────────────────────────────────────────
 
 func TestAdminUserService_SetEnabled_SelfDisableBlocked(t *testing.T) {
-	svc, us, _ := newAdminUserSvc(t)
+	svc, us, _, _ := newAdminUserSvc(t)
 	ctx := context.Background()
 	seedAdminUser(t, us, "uuid-self", "admin", true)
 
@@ -48,7 +65,7 @@ func TestAdminUserService_SetEnabled_SelfDisableBlocked(t *testing.T) {
 }
 
 func TestAdminUserService_SetEnabled_LastAdminDisableBlocked(t *testing.T) {
-	svc, us, _ := newAdminUserSvc(t)
+	svc, us, _, _ := newAdminUserSvc(t)
 	ctx := context.Background()
 	seedAdminUser(t, us, "uuid-only", "admin", true)
 
@@ -60,7 +77,7 @@ func TestAdminUserService_SetEnabled_LastAdminDisableBlocked(t *testing.T) {
 }
 
 func TestAdminUserService_SetEnabled_NonLastAdminCanBeDisabled(t *testing.T) {
-	svc, us, _ := newAdminUserSvc(t)
+	svc, us, _, _ := newAdminUserSvc(t)
 	ctx := context.Background()
 	seedAdminUser(t, us, "uuid-a", "admin", true)
 	seedAdminUser(t, us, "uuid-b", "admin", true)
@@ -72,7 +89,7 @@ func TestAdminUserService_SetEnabled_NonLastAdminCanBeDisabled(t *testing.T) {
 }
 
 func TestAdminUserService_SetEnabled_NonAdminRoleUserCanBeDisabled(t *testing.T) {
-	svc, us, _ := newAdminUserSvc(t)
+	svc, us, _, _ := newAdminUserSvc(t)
 	ctx := context.Background()
 	seedAdminUser(t, us, "uuid-admin", "admin", true)
 	seedAdminUser(t, us, "uuid-op", "operator", true)
@@ -83,85 +100,145 @@ func TestAdminUserService_SetEnabled_NonAdminRoleUserCanBeDisabled(t *testing.T)
 	}
 }
 
+func TestAdminUserService_SetEnabled_AuditDisable(t *testing.T) {
+	svc, us, _, as := newAdminUserSvc(t)
+	ctx := context.Background()
+	seedAdminUser(t, us, "uuid-a", "admin", true)
+	seedAdminUser(t, us, "uuid-b", "admin", true)
+
+	if err := svc.SetEnabled(ctx, "uuid-a", "uuid-b", false); err != nil {
+		t.Fatalf("SetEnabled: %v", err)
+	}
+	requireAuditEntry(t, as, "admin_user.disabled", "uuid-a")
+}
+
+func TestAdminUserService_SetEnabled_AuditEnable(t *testing.T) {
+	svc, us, _, as := newAdminUserSvc(t)
+	ctx := context.Background()
+	seedAdminUser(t, us, "uuid-admin", "admin", true)
+	seedAdminUser(t, us, "uuid-op", "operator", false)
+
+	if err := svc.SetEnabled(ctx, "uuid-op", "uuid-admin", true); err != nil {
+		t.Fatalf("SetEnabled: %v", err)
+	}
+	requireAuditEntry(t, as, "admin_user.enabled", "uuid-op")
+}
+
 // ── AssignRole ────────────────────────────────────────────────────────────────
 
 func TestAdminUserService_AssignRole_LastAdminRoleMoveBlocked(t *testing.T) {
-	svc, us, _ := newAdminUserSvc(t)
+	svc, us, _, _ := newAdminUserSvc(t)
 	ctx := context.Background()
 	seedAdminUser(t, us, "uuid-only", "admin", true)
 
-	err := svc.AssignRole(ctx, "uuid-only", "operator")
+	err := svc.AssignRole(ctx, "uuid-caller", "uuid-only", "operator")
 	if !errors.Is(err, service.ErrLastAdmin) {
 		t.Fatalf("expected ErrLastAdmin, got: %v", err)
 	}
 }
 
 func TestAdminUserService_AssignRole_NonLastAdminRoleMoveAllowed(t *testing.T) {
-	svc, us, _ := newAdminUserSvc(t)
+	svc, us, _, _ := newAdminUserSvc(t)
 	ctx := context.Background()
 	seedAdminUser(t, us, "uuid-a", "admin", true)
 	seedAdminUser(t, us, "uuid-b", "admin", true)
 
 	// Moving uuid-a to operator is fine because uuid-b still holds admin.
-	if err := svc.AssignRole(ctx, "uuid-a", "operator"); err != nil {
+	if err := svc.AssignRole(ctx, "uuid-b", "uuid-a", "operator"); err != nil {
 		t.Fatalf("unexpected error moving non-last admin to operator: %v", err)
 	}
 }
 
 func TestAdminUserService_AssignRole_ToAdminAlwaysAllowed(t *testing.T) {
-	svc, us, _ := newAdminUserSvc(t)
+	svc, us, _, _ := newAdminUserSvc(t)
 	ctx := context.Background()
 	seedAdminUser(t, us, "uuid-admin", "admin", true)
 	seedAdminUser(t, us, "uuid-op", "operator", true)
 
 	// Elevating an operator to admin should never be blocked by the last-admin guard.
-	if err := svc.AssignRole(ctx, "uuid-op", "admin"); err != nil {
+	if err := svc.AssignRole(ctx, "uuid-admin", "uuid-op", "admin"); err != nil {
 		t.Fatalf("unexpected error promoting operator to admin: %v", err)
 	}
+}
+
+func TestAdminUserService_AssignRole_AuditRoleAssigned(t *testing.T) {
+	svc, us, _, as := newAdminUserSvc(t)
+	ctx := context.Background()
+	seedAdminUser(t, us, "uuid-a", "admin", true)
+	seedAdminUser(t, us, "uuid-b", "admin", true)
+
+	if err := svc.AssignRole(ctx, "uuid-b", "uuid-a", "operator"); err != nil {
+		t.Fatalf("AssignRole: %v", err)
+	}
+	requireAuditEntry(t, as, "admin_user.role_assigned", "uuid-a")
 }
 
 // ── SetExpiry ─────────────────────────────────────────────────────────────────
 
 func TestAdminUserService_SetExpiry_LastAdminBlocked(t *testing.T) {
-	svc, us, _ := newAdminUserSvc(t)
+	svc, us, _, _ := newAdminUserSvc(t)
 	ctx := context.Background()
 	seedAdminUser(t, us, "uuid-only", "admin", true)
 
 	future := time.Now().Add(24 * time.Hour)
-	err := svc.SetExpiry(ctx, "uuid-only", &future)
+	err := svc.SetExpiry(ctx, "uuid-caller", "uuid-only", &future)
 	if !errors.Is(err, service.ErrLastAdmin) {
 		t.Fatalf("expected ErrLastAdmin, got: %v", err)
 	}
 }
 
 func TestAdminUserService_SetExpiry_ClearAlwaysAllowed(t *testing.T) {
-	svc, us, _ := newAdminUserSvc(t)
+	svc, us, _, _ := newAdminUserSvc(t)
 	ctx := context.Background()
 	seedAdminUser(t, us, "uuid-only", "admin", true)
 
 	// Clearing expiry (nil) must never be blocked by the last-admin guard.
-	if err := svc.SetExpiry(ctx, "uuid-only", nil); err != nil {
+	if err := svc.SetExpiry(ctx, "uuid-caller", "uuid-only", nil); err != nil {
 		t.Fatalf("unexpected error clearing expiry on last admin: %v", err)
 	}
 }
 
 func TestAdminUserService_SetExpiry_NonLastAdminAllowed(t *testing.T) {
-	svc, us, _ := newAdminUserSvc(t)
+	svc, us, _, _ := newAdminUserSvc(t)
 	ctx := context.Background()
 	seedAdminUser(t, us, "uuid-a", "admin", true)
 	seedAdminUser(t, us, "uuid-b", "admin", true)
 
 	future := time.Now().Add(24 * time.Hour)
 	// Setting expiry on uuid-a is fine because uuid-b still qualifies.
-	if err := svc.SetExpiry(ctx, "uuid-a", &future); err != nil {
+	if err := svc.SetExpiry(ctx, "uuid-b", "uuid-a", &future); err != nil {
 		t.Fatalf("unexpected error setting expiry on non-last admin: %v", err)
 	}
+}
+
+func TestAdminUserService_SetExpiry_AuditExpirySet(t *testing.T) {
+	svc, us, _, as := newAdminUserSvc(t)
+	ctx := context.Background()
+	seedAdminUser(t, us, "uuid-a", "admin", true)
+	seedAdminUser(t, us, "uuid-b", "admin", true)
+
+	future := time.Now().Add(24 * time.Hour)
+	if err := svc.SetExpiry(ctx, "uuid-b", "uuid-a", &future); err != nil {
+		t.Fatalf("SetExpiry: %v", err)
+	}
+	requireAuditEntry(t, as, "admin_user.expiry_set", "uuid-a")
+}
+
+func TestAdminUserService_SetExpiry_AuditExpiryClear(t *testing.T) {
+	svc, us, _, as := newAdminUserSvc(t)
+	ctx := context.Background()
+	seedAdminUser(t, us, "uuid-only", "admin", true)
+
+	if err := svc.SetExpiry(ctx, "uuid-caller", "uuid-only", nil); err != nil {
+		t.Fatalf("SetExpiry clear: %v", err)
+	}
+	requireAuditEntry(t, as, "admin_user.expiry_set", "uuid-only")
 }
 
 // TestAdminUserService_SetEnabled_ExpiredAdminNotCounted verifies that an
 // expired admin account does not count toward the last-admin threshold.
 func TestAdminUserService_SetEnabled_ExpiredAdminNotCounted(t *testing.T) {
-	_, us, _ := newAdminUserSvc(t)
+	_, us, _, _ := newAdminUserSvc(t)
 	ctx := context.Background()
 
 	// Create two admins, then expire uuid-a via the store directly.
@@ -178,7 +255,7 @@ func TestAdminUserService_SetEnabled_ExpiredAdminNotCounted(t *testing.T) {
 	}
 
 	// Now uuid-b is the only qualifying admin. Disabling uuid-b must fail.
-	svc2, _, _ := newAdminUserSvc(t)
+	svc2, _, _, _ := newAdminUserSvc(t)
 	// Re-wire on same DB — use a fresh svc against the same us.
 	_ = svc2 // svc2 uses a different in-memory DB; re-use the store directly.
 


### PR DESCRIPTION
AdminUserService has no auditStore field, NewAdminUserService doesn't accept one, and SetEnabled (along with every other mutating method on the service) never calls any audit logging function. By contrast, ModuleAuthorizationService and ProvisionService both take a store.AuditStore in their constructors and call a recordAudit helper after every state change. AdminUserService was simply never wired up the same way, and main.go line 127 constructs it without one.