### PR TITLE
update main and fix header reference

### DIFF
--- a/access_module/main/main.cpp
+++ b/access_module/main/main.cpp
@@ -41,6 +41,11 @@
 #include "server_comm.hpp"
 #endif
 
+/* Interface types — needed unconditionally for pointer declarations below */
+#include "i_credential_reader.hpp"
+#include "i_access_point.hpp"
+#include "i_feedback.hpp"
+
 /* Concrete module implementations */
 #ifdef CONFIG_PORTUNUS_ENABLE_MFRC522
 #include "reader_mfrc522.hpp"


### PR DESCRIPTION
Those two IDE diagnostics (freertos/FreeRTOS.h, driver/gpio.h) are pre-existing IntelliSense noise — the IDE doesn't have ESP-IDF's include paths configured, so it can't resolve ESP-IDF system headers. They were there before my change and won't affect the actual idf.py/task firmware:build toolchain, which knows where those headers live.

The fix for your original error: added unconditional includes for all three interface headers (i_credential_reader.hpp, i_access_point.hpp, i_feedback.hpp) in [main.cpp:44-47](vscode-webview://0itnmuc63fsajdft0n8foh9k0dl1jje9s444dejl4jajsbc6fuf4/access_module/main/main.cpp#L44-L47). This makes the base pointer types available regardless of which FSM variant or driver combination is selected by Kconfig.