### PR TITLE
add error reporting to heartbeat

### DIFF
--- a/access_module/components/portunus_types/include/credential_types.h
+++ b/access_module/components/portunus_types/include/credential_types.h
@@ -30,6 +30,9 @@ typedef struct {
 /** Buffer size sufficient for any UID formatted as "XX:XX:...:XX\0". */
 #define CREDENTIAL_UID_HEX_STR_LEN  (CREDENTIAL_UID_MAX_LEN * 3 + 1)
 
+/** Buffer size for the 8-character FNV-1a log fingerprint plus NUL. */
+#define CREDENTIAL_LOG_ID_LEN  9
+
 /**
  * @brief Format a credential UID as a colon-separated hex string.
  *
@@ -40,6 +43,19 @@ typedef struct {
  * @param buf_len Size of buf in bytes.
  */
 void credential_uid_to_hex(const credential_t *cred, char *buf, size_t buf_len);
+
+/**
+ * @brief Produce a short, non-reversible log fingerprint of a credential UID.
+ *
+ * Computes FNV-1a 32-bit over the raw UID bytes and formats the result as
+ * 8 lowercase hex characters.  Suitable for log correlation without exposing
+ * the raw UID.  Buf must be at least CREDENTIAL_LOG_ID_LEN bytes.
+ *
+ * @param cred    Source credential.
+ * @param buf     Destination buffer (recommend CREDENTIAL_LOG_ID_LEN).
+ * @param buf_len Size of buf in bytes.
+ */
+void credential_uid_to_log_id(const credential_t *cred, char *buf, size_t buf_len);
 
 #ifdef __cplusplus
 }

--- a/access_module/components/portunus_types/include/event_types.hpp
+++ b/access_module/components/portunus_types/include/event_types.hpp
@@ -32,7 +32,8 @@ typedef enum {
 
     /* Credential events: 0x01xx */
     EVENT_CREDENTIAL_READ = 0x0100,    /**< Card UID successfully read */
-    EVENT_CREDENTIAL_READ_ERROR,       /**< Card read attempted but failed */
+    EVENT_CREDENTIAL_READ_ERROR,       /**< Reader hardware fault — entering degraded mode */
+    EVENT_CREDENTIAL_READER_RECOVERED, /**< Reader hardware recovered after fault */
 
     /* Heartbeat events: 0x02xx */
     EVENT_HEARTBEAT = 0x0200,          /**< Periodic health tick */
@@ -84,7 +85,7 @@ typedef struct {
  * the decision without needing to know about protobuf or HTTP.
  */
 typedef struct {
-    char     credential_id[30];        /**< Hex-encoded credential UID that was checked */
+    char     credential_id[30];        /**< FNV-1a log fingerprint of the credential (never raw UID) */
     char     reason[33];               /**< Server reason code, e.g. "allow_all" */
     bool     granted;                  /**< true = access granted */
     bool     known;                    /**< true = module is registered on server */

--- a/access_module/components/portunus_types/src/credential_types.c
+++ b/access_module/components/portunus_types/src/credential_types.c
@@ -1,5 +1,7 @@
 #include "credential_types.h"
 
+#include <stdint.h>
+
 void credential_uid_to_hex(const credential_t *cred, char *buf, size_t buf_len)
 {
     static const char hex[] = "0123456789ABCDEF";
@@ -11,4 +13,30 @@ void credential_uid_to_hex(const credential_t *cred, char *buf, size_t buf_len)
         buf[pos++] = hex[cred->uid[i] & 0x0F];
     }
     buf[pos] = '\0';
+}
+
+void credential_uid_to_log_id(const credential_t *cred, char *buf, size_t buf_len)
+{
+    static const char hex[] = "0123456789abcdef";
+
+    if (buf_len < CREDENTIAL_LOG_ID_LEN || cred->uid_len == 0) {
+        if (buf_len > 0) buf[0] = '\0';
+        return;
+    }
+
+    uint32_t h = 2166136261u;  /* FNV-1a 32-bit offset basis */
+    for (uint8_t i = 0; i < cred->uid_len; i++) {
+        h ^= cred->uid[i];
+        h *= 16777619u;  /* FNV prime */
+    }
+
+    buf[0] = hex[(h >> 28) & 0xF];
+    buf[1] = hex[(h >> 24) & 0xF];
+    buf[2] = hex[(h >> 20) & 0xF];
+    buf[3] = hex[(h >> 16) & 0xF];
+    buf[4] = hex[(h >> 12) & 0xF];
+    buf[5] = hex[(h >>  8) & 0xF];
+    buf[6] = hex[(h >>  4) & 0xF];
+    buf[7] = hex[(h >>  0) & 0xF];
+    buf[8] = '\0';
 }

--- a/access_module/core/provisioning_fsm/src/provisioning_fsm.cpp
+++ b/access_module/core/provisioning_fsm/src/provisioning_fsm.cpp
@@ -326,15 +326,14 @@ void ProvisioningFSM::handle_arm_requested()
 
 void ProvisioningFSM::handle_credential_read(const event_credential_read_t *cred)
 {
-    char uid_str[CREDENTIAL_UID_HEX_STR_LEN];
-    credential_uid_to_hex(&cred->credential, uid_str, sizeof(uid_str));
-
     if (m_state != PEU_STATE_ARMED) {
         ESP_LOGD(TAG, "Credential read ignored in state %d", (int)m_state);
         return;
     }
 
-    ESP_LOGI(TAG, "Card read — UID: %s", uid_str);
+    char log_id[CREDENTIAL_LOG_ID_LEN];
+    credential_uid_to_log_id(&cred->credential, log_id, sizeof(log_id));
+    ESP_LOGI(TAG, "Card read — id=%s", log_id);
     publish_capture_request(cred);
     m_state       = PEU_STATE_CAPTURE_SEND;
     m_deadline_ms = 0;

--- a/access_module/core/system_fsm/src/system_fsm.cpp
+++ b/access_module/core/system_fsm/src/system_fsm.cpp
@@ -43,11 +43,13 @@ static const char *TAG = "fsm";
 
 /* ── Task configuration ───────────────────────────────────────────────────── */
 
-static const int FSM_TASK_STACK      = 4096;
-static const int FSM_TASK_PRIORITY   = 5;   /* Above card polling, same as dispatcher */
-static const int POLL_TASK_STACK     = 4096;
-static const int POLL_TASK_PRIORITY  = 4;   /* Between heartbeat (3) and FSM (5) */
-static const int FSM_EVENT_QUEUE_LEN = 8;
+static const int FSM_TASK_STACK             = 4096;
+static const int FSM_TASK_PRIORITY          = 5;   /* Above card polling, same as dispatcher */
+static const int POLL_TASK_STACK            = 4096;
+static const int POLL_TASK_PRIORITY         = 4;   /* Between heartbeat (3) and FSM (5) */
+static const int FSM_EVENT_QUEUE_LEN        = 8;
+static const int READER_HW_ERROR_THRESHOLD  = 5;    /* consecutive non-NO_CREDENTIAL errors before degraded */
+static const int READER_RECOVERY_INTERVAL_MS = 5000; /* ms between reconnection attempts when degraded */
 
 /* ── Helper: current time in milliseconds ─────────────────────────────────── */
 
@@ -285,11 +287,10 @@ void SystemFSM::process_event(const portunus_event_t &event)
 
     case EVENT_CREDENTIAL_READ: {
         const event_credential_read_t *cred = &event.payload.credential_read;
-        char uid_str[CREDENTIAL_UID_HEX_STR_LEN];
-        credential_uid_to_hex(&cred->credential, uid_str, sizeof(uid_str));
+        char log_id[CREDENTIAL_LOG_ID_LEN];
+        credential_uid_to_log_id(&cred->credential, log_id, sizeof(log_id));
 
-        ESP_LOGI(TAG, "Credential read — UID: %s (len=%d)",
-                 uid_str, cred->credential.uid_len);
+        ESP_LOGI(TAG, "Credential read — id=%s", log_id);
 
         /* Show intermediate feedback while waiting for server decision. */
         if (m_caps.has_feedback) {
@@ -429,30 +430,71 @@ void SystemFSM::check_unlock_timer()
 
 void SystemFSM::poll_credential()
 {
-    const TickType_t poll_interval  = pdMS_TO_TICKS(MFRC522_POLL_INTERVAL_MS);
-    const TickType_t reread_delay   = pdMS_TO_TICKS(CARD_REREAD_DELAY_MS);
+    const TickType_t poll_interval = pdMS_TO_TICKS(MFRC522_POLL_INTERVAL_MS);
+    const TickType_t reread_delay  = pdMS_TO_TICKS(CARD_REREAD_DELAY_MS);
+
+    int  consecutive_hw_errors = 0;
+    bool reader_degraded       = false;
 
     for (;;) {
+        /* Recovery mode: chip absent, probe for reconnection periodically. */
+        if (reader_degraded) {
+            vTaskDelay(pdMS_TO_TICKS(READER_RECOVERY_INTERVAL_MS));
+            if (m_reader->init() == PORTUNUS_OK) {
+                ESP_LOGI(TAG, "Credential reader recovered — resuming polling");
+                m_caps.has_reader    = true;
+                reader_degraded      = false;
+                consecutive_hw_errors = 0;
+
+                portunus_event_t recovery_event;
+                memset(&recovery_event, 0, sizeof(recovery_event));
+                recovery_event.id = EVENT_CREDENTIAL_READER_RECOVERED;
+                event_bus_publish(&recovery_event);
+            } else {
+                ESP_LOGD(TAG, "Credential reader still absent — retrying in %d ms",
+                         READER_RECOVERY_INTERVAL_MS);
+            }
+            continue;
+        }
+
         credential_t cred;
         portunus_err_t err = m_reader->read(&cred);
 
         if (err == PORTUNUS_OK) {
-            /* Build and publish credential event via event bus. */
+            consecutive_hw_errors = 0;
+
             portunus_event_t event;
             memset(&event, 0, sizeof(event));
-            event.id = EVENT_CREDENTIAL_READ;
+            event.id                                   = EVENT_CREDENTIAL_READ;
             event.payload.credential_read.credential   = cred;
             event.payload.credential_read.timestamp_ms = now_ms();
-
             event_bus_publish(&event);
 
-            /* Halt the credential to prevent re-reads while held against reader. */
             m_reader->halt();
-
             vTaskDelay(reread_delay);
             continue;
         }
-        /* PORTUNUS_ERR_NO_CREDENTIAL is expected — no credential present, continue. */
+
+        if (err == PORTUNUS_ERR_NO_CREDENTIAL) {
+            /* Expected — no card in field, chip is healthy. */
+            consecutive_hw_errors = 0;
+        } else {
+            /* Hardware fault (timeout, SPI error, read error, etc.). */
+            if (++consecutive_hw_errors >= READER_HW_ERROR_THRESHOLD) {
+                ESP_LOGW(TAG, "Credential reader hardware fault after %d errors "
+                         "(last err=0x%x) — entering degraded mode",
+                         consecutive_hw_errors, err);
+                m_caps.has_reader = false;
+                reader_degraded   = true;
+
+                portunus_event_t fault_event;
+                memset(&fault_event, 0, sizeof(fault_event));
+                fault_event.id = EVENT_CREDENTIAL_READ_ERROR;
+                event_bus_publish(&fault_event);
+
+                continue;
+            }
+        }
 
         vTaskDelay(poll_interval);
     }

--- a/access_module/drivers/reader_mfrc522/src/mfrc522_hal.cpp
+++ b/access_module/drivers/reader_mfrc522/src/mfrc522_hal.cpp
@@ -89,8 +89,9 @@ static const char *TAG = "mfrc522";
 
 /* ── Module state ──────────────────────────────────────────────────────────── */
 
-static spi_device_handle_t s_spi_handle = NULL;
-static bool                s_spi_error  = false;  /* set by reg_read on transfer failure */
+static spi_device_handle_t s_spi_handle     = NULL;
+static bool                s_spi_error      = false; /* set by reg_read on transfer failure */
+static bool                s_spi_initialized = false; /* SPI bus + device added; skip on re-init */
 
 /* ── Low-level SPI register access ─────────────────────────────────────────── */
 
@@ -356,49 +357,53 @@ static portunus_err_t picc_anticoll_select(uint8_t sel_cmd, uint8_t *uid_part)
 
 portunus_err_t mfrc522_init(void)
 {
-    /* ── Configure RST pin and perform hardware reset ────────────────────── */
+    /* ── RST pin: configure on first call, toggle on every call ─────────── */
     if (PIN_MFRC522_RST >= 0) {
-        gpio_config_t rst_cfg = {};
-        rst_cfg.pin_bit_mask = (1ULL << PIN_MFRC522_RST);
-        rst_cfg.mode         = GPIO_MODE_OUTPUT;
-        rst_cfg.pull_up_en   = GPIO_PULLUP_DISABLE;
-        rst_cfg.pull_down_en = GPIO_PULLDOWN_DISABLE;
-        rst_cfg.intr_type    = GPIO_INTR_DISABLE;
-        gpio_config(&rst_cfg);
-
+        if (!s_spi_initialized) {
+            gpio_config_t rst_cfg = {};
+            rst_cfg.pin_bit_mask = (1ULL << PIN_MFRC522_RST);
+            rst_cfg.mode         = GPIO_MODE_OUTPUT;
+            rst_cfg.pull_up_en   = GPIO_PULLUP_DISABLE;
+            rst_cfg.pull_down_en = GPIO_PULLDOWN_DISABLE;
+            rst_cfg.intr_type    = GPIO_INTR_DISABLE;
+            gpio_config(&rst_cfg);
+        }
         gpio_set_level((gpio_num_t)PIN_MFRC522_RST, 0);
         vTaskDelay(pdMS_TO_TICKS(10));
         gpio_set_level((gpio_num_t)PIN_MFRC522_RST, 1);
         vTaskDelay(pdMS_TO_TICKS(50));
     }
 
-    /* ── Initialise SPI bus ──────────────────────────────────────────────── */
-    spi_bus_config_t bus_cfg = {};
-    bus_cfg.mosi_io_num     = PIN_SPI_MOSI;
-    bus_cfg.miso_io_num     = PIN_SPI_MISO;
-    bus_cfg.sclk_io_num     = PIN_SPI_SCLK;
-    bus_cfg.quadwp_io_num   = -1;
-    bus_cfg.quadhd_io_num   = -1;
-    bus_cfg.max_transfer_sz = 64;
+    /* ── SPI bus and device: initialise once, reuse on recovery calls ─────── */
+    if (!s_spi_initialized) {
+        spi_bus_config_t bus_cfg = {};
+        bus_cfg.mosi_io_num     = PIN_SPI_MOSI;
+        bus_cfg.miso_io_num     = PIN_SPI_MISO;
+        bus_cfg.sclk_io_num     = PIN_SPI_SCLK;
+        bus_cfg.quadwp_io_num   = -1;
+        bus_cfg.quadhd_io_num   = -1;
+        bus_cfg.max_transfer_sz = 64;
 
-    esp_err_t ret = spi_bus_initialize(MFRC522_SPI_HOST, &bus_cfg, SPI_DMA_CH_AUTO);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "SPI bus init failed: %s", esp_err_to_name(ret));
-        return PORTUNUS_ERR_SPI_INIT;
-    }
+        esp_err_t ret = spi_bus_initialize(MFRC522_SPI_HOST, &bus_cfg, SPI_DMA_CH_AUTO);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "SPI bus init failed: %s", esp_err_to_name(ret));
+            return PORTUNUS_ERR_SPI_INIT;
+        }
 
-    /* ── Add MFRC522 as SPI device ───────────────────────────────────────── */
-    spi_device_interface_config_t dev_cfg = {};
-    dev_cfg.clock_speed_hz = MFRC522_SPI_CLOCK_HZ;
-    dev_cfg.mode           = 0;          /* CPOL=0, CPHA=0 */
-    dev_cfg.spics_io_num   = PIN_MFRC522_CS;
-    dev_cfg.queue_size     = 4;
+        spi_device_interface_config_t dev_cfg = {};
+        dev_cfg.clock_speed_hz = MFRC522_SPI_CLOCK_HZ;
+        dev_cfg.mode           = 0;          /* CPOL=0, CPHA=0 */
+        dev_cfg.spics_io_num   = PIN_MFRC522_CS;
+        dev_cfg.queue_size     = 4;
 
-    ret = spi_bus_add_device(MFRC522_SPI_HOST, &dev_cfg, &s_spi_handle);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "SPI add device failed: %s", esp_err_to_name(ret));
-        spi_bus_free(MFRC522_SPI_HOST);
-        return PORTUNUS_ERR_SPI_INIT;
+        ret = spi_bus_add_device(MFRC522_SPI_HOST, &dev_cfg, &s_spi_handle);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "SPI add device failed: %s", esp_err_to_name(ret));
+            spi_bus_free(MFRC522_SPI_HOST);
+            return PORTUNUS_ERR_SPI_INIT;
+        }
+
+        s_spi_initialized = true;
     }
 
     /* ── Soft reset ──────────────────────────────────────────────────────── */
@@ -435,7 +440,6 @@ portunus_err_t mfrc522_init(void)
     }
     ESP_LOGI(TAG, "MFRC522 detected, version=0x%02x", version);
 
-    /* Turn antenna on */
     mfrc522_antenna_on();
 
     return PORTUNUS_OK;

--- a/access_module/main/Kconfig.projbuild
+++ b/access_module/main/Kconfig.projbuild
@@ -17,6 +17,7 @@ menu "Portunus Configuration"
 
             config PORTUNUS_MODULE_TYPE_ACCESS_POINT
                 bool "Access point (door control)"
+                imply PORTUNUS_ENABLE_DOOR_STRIKE
 
             config PORTUNUS_MODULE_TYPE_PROVISIONING_CONSOLE
                 bool "Provisioning console (credential enrollment)"

--- a/access_module/services/server_comm/src/server_comm.cpp
+++ b/access_module/services/server_comm/src/server_comm.cpp
@@ -86,9 +86,10 @@ static const char *TAG = "server_comm";
 #define URL_MAX_LEN            128
 
 /* ── Module state ──────────────────────────────────────────────────────────── */
-static QueueHandle_t  s_comm_queue   = NULL;
-static TaskHandle_t   s_comm_task    = NULL;
-static bool           s_initialized  = false;
+static QueueHandle_t  s_comm_queue    = NULL;
+static TaskHandle_t   s_comm_task     = NULL;
+static bool           s_initialized   = false;
+static bool           s_reader_degraded = false; /* set by EVENT_CREDENTIAL_READ_ERROR, cleared by RECOVERED */
 
 #if PORTUNUS_USE_GRPC
 /* gRPC client handle — persistent HTTP/2+TLS connection to the server. */
@@ -373,6 +374,13 @@ static void on_heartbeat_event(const portunus_event_t *event, void *ctx)
     xQueueSend(s_comm_queue, event, 0);
 }
 
+static void on_reader_fault_event(const portunus_event_t *event, void *ctx)
+{
+    (void)ctx;
+    if (s_comm_queue == NULL) { return; }
+    xQueueSend(s_comm_queue, event, 0);
+}
+
 #ifdef CONFIG_PORTUNUS_MODULE_TYPE_ACCESS_POINT
 static void on_credential_event(const portunus_event_t *event, void *ctx)
 {
@@ -400,7 +408,7 @@ static void on_provision_event(const portunus_event_t *event, void *ctx)
  * response, decode failure) so the user always sees a deny indication
  * rather than the CARD_READ LED stuck on indefinitely.
  *
- * @param credential_id  Hex-encoded credential UID (may be empty if unknown).
+ * @param credential_id  FNV-1a log fingerprint of the credential (never raw UID).
  * @param reason         Short reason string for logs / audit trail.
  */
 static void publish_access_denied(const char *credential_id, const char *reason)
@@ -497,8 +505,13 @@ static void handle_heartbeat(const event_heartbeat_t *hb)
         return;
     }
 
-    ESP_LOGI(TAG, "Heartbeat OK — known=%d server_time=%s",
-             resp.known, resp.server_time);
+    if (s_reader_degraded) {
+        ESP_LOGW(TAG, "Heartbeat OK — known=%d server_time=%s [READER DEGRADED]",
+                 resp.known, resp.server_time);
+    } else {
+        ESP_LOGI(TAG, "Heartbeat OK — known=%d server_time=%s",
+                 resp.known, resp.server_time);
+    }
 }
 
 #ifdef CONFIG_PORTUNUS_MODULE_TYPE_ACCESS_POINT
@@ -510,12 +523,15 @@ static void handle_credential(const event_credential_read_t *cred)
     strncpy(req.module_id, PORTUNUS_MODULE_ID, sizeof(req.module_id) - 1);
     credential_uid_to_hex(&cred->credential, req.credential_id, sizeof(req.credential_id));
 
+    char req_log_id[CREDENTIAL_LOG_ID_LEN];
+    credential_uid_to_log_id(&cred->credential, req_log_id, sizeof(req_log_id));
+
     /* Encode */
     uint8_t req_buf[portunus_v1_AccessRequest_size];
     pb_ostream_t ostream = pb_ostream_from_buffer(req_buf, sizeof(req_buf));
     if (!pb_encode(&ostream, portunus_v1_AccessRequest_fields, &req)) {
         ESP_LOGE(TAG, "Access encode failed: %s", PB_GET_ERROR(&ostream));
-        publish_access_denied(req.credential_id, "encode_error");
+        publish_access_denied(req_log_id, "encode_error");
         return;
     }
 
@@ -535,12 +551,12 @@ static void handle_credential(const event_credential_read_t *cred)
         &resp_len, &grpc_status);
     if (err != PORTUNUS_OK) {
         ESP_LOGW(TAG, "Access gRPC failed: err=0x%04x", (unsigned)err);
-        publish_access_denied(req.credential_id, "grpc_error");
+        publish_access_denied(req_log_id, "grpc_error");
         return;
     }
     if (grpc_status != GRPC_STATUS_OK) {
         ESP_LOGW(TAG, "Access gRPC status: %d", grpc_status);
-        publish_access_denied(req.credential_id, "grpc_status_error");
+        publish_access_denied(req_log_id, "grpc_status_error");
         return;
     }
 #else
@@ -551,13 +567,13 @@ static void handle_credential(const event_credential_read_t *cred)
                                          &resp_len, &status);
     if (err != PORTUNUS_OK) {
         ESP_LOGW(TAG, "Access HTTP failed: err=0x%04x", (unsigned)err);
-        publish_access_denied(req.credential_id, "http_error");
+        publish_access_denied(req_log_id, "http_error");
         return;
     }
 
     if (status != 200) {
         ESP_LOGW(TAG, "Access server returned HTTP %d", status);
-        publish_access_denied(req.credential_id, "http_status_error");
+        publish_access_denied(req_log_id, "http_status_error");
         return;
     }
 #endif /* PORTUNUS_USE_GRPC */
@@ -567,19 +583,19 @@ static void handle_credential(const event_credential_read_t *cred)
     pb_istream_t istream = pb_istream_from_buffer(resp_buf, (size_t)resp_len);
     if (!pb_decode(&istream, portunus_v1_AccessResponse_fields, &resp)) {
         ESP_LOGW(TAG, "Access decode failed: %s", PB_GET_ERROR(&istream));
-        publish_access_denied(req.credential_id, "decode_error");
+        publish_access_denied(req_log_id, "decode_error");
         return;
     }
 
-    ESP_LOGI(TAG, "Access decision — credential=%s granted=%d reason=%s known=%d",
-             req.credential_id, resp.granted, resp.reason, resp.known);
+    ESP_LOGI(TAG, "Access decision — id=%s granted=%d reason=%s known=%d",
+             req_log_id, resp.granted, resp.reason, resp.known);
 
     /* Publish decision event back to the bus */
     portunus_event_t decision;
     memset(&decision, 0, sizeof(decision));
     decision.id = resp.granted ? EVENT_ACCESS_GRANTED : EVENT_ACCESS_DENIED;
 
-    strncpy(decision.payload.access_decision.credential_id, req.credential_id,
+    strncpy(decision.payload.access_decision.credential_id, req_log_id,
             sizeof(decision.payload.access_decision.credential_id) - 1);
     strncpy(decision.payload.access_decision.reason, resp.reason,
             sizeof(decision.payload.access_decision.reason) - 1);
@@ -760,10 +776,10 @@ static void comm_task(void *arg)
             /* Credential events need a deny so the FSM clears CARD_READ
                feedback.  Heartbeats can be silently dropped. */
             if (event.id == EVENT_CREDENTIAL_READ) {
-                char credential_id[CREDENTIAL_UID_HEX_STR_LEN];
-                credential_uid_to_hex(&event.payload.credential_read.credential,
-                                      credential_id, sizeof(credential_id));
-                publish_access_denied(credential_id, "no_network");
+                char log_id[CREDENTIAL_LOG_ID_LEN];
+                credential_uid_to_log_id(&event.payload.credential_read.credential,
+                                         log_id, sizeof(log_id));
+                publish_access_denied(log_id, "no_network");
             }
             continue;
         }
@@ -782,6 +798,14 @@ static void comm_task(void *arg)
             handle_provision(&event.payload.provision_request);
             break;
 #endif
+        case EVENT_CREDENTIAL_READ_ERROR:
+            s_reader_degraded = true;
+            ESP_LOGW(TAG, "Credential reader degraded — heartbeats will reflect fault");
+            break;
+        case EVENT_CREDENTIAL_READER_RECOVERED:
+            s_reader_degraded = false;
+            ESP_LOGI(TAG, "Credential reader recovered — heartbeats nominal");
+            break;
         default:
             ESP_LOGW(TAG, "Unexpected event 0x%04x in comm queue",
                      (unsigned)event.id);
@@ -873,6 +897,16 @@ portunus_err_t server_comm_init(void)
     sub_err = event_bus_subscribe(EVENT_HEARTBEAT, on_heartbeat_event, NULL);
     if (sub_err != PORTUNUS_OK) {
         ESP_LOGE(TAG, "Failed to subscribe to heartbeat events: 0x%04x", (unsigned)sub_err);
+    }
+
+    sub_err = event_bus_subscribe(EVENT_CREDENTIAL_READ_ERROR, on_reader_fault_event, NULL);
+    if (sub_err != PORTUNUS_OK) {
+        ESP_LOGE(TAG, "Failed to subscribe to reader error events: 0x%04x", (unsigned)sub_err);
+    }
+
+    sub_err = event_bus_subscribe(EVENT_CREDENTIAL_READER_RECOVERED, on_reader_fault_event, NULL);
+    if (sub_err != PORTUNUS_OK) {
+        ESP_LOGE(TAG, "Failed to subscribe to reader recovery events: 0x%04x", (unsigned)sub_err);
     }
 
 #ifdef CONFIG_PORTUNUS_MODULE_TYPE_ACCESS_POINT


### PR DESCRIPTION
event_types.hpp — Added EVENT_CREDENTIAL_READER_RECOVERED (0x0102) to the credential events group. Append-only, backward compatible.

system_fsm.cpp — In the recovery loop, when m_reader->init() succeeds, publishes EVENT_CREDENTIAL_READER_RECOVERED so subscribers know the hardware is back.

server_comm.cpp — Three changes:

s_reader_degraded flag at module scope
on_reader_fault_event() callback (shared by both fault and recovery — both just copy the event into the comm queue; the comm_task switch distinguishes them)
comm_task switch handles EVENT_CREDENTIAL_READ_ERROR → sets flag; EVENT_CREDENTIAL_READER_RECOVERED → clears flag
Subscriptions for both new events in server_comm_init()
Heartbeat log now emits LOGW with [READER DEGRADED] when the flag is set, LOGI otherwise
Result in the serial monitor:

Reader disconnected: fsm: Credential reader hardware fault after 5 errors — entering degraded mode → server_comm: Credential reader degraded — heartbeats will reflect fault → subsequent heartbeats: server_comm: Heartbeat OK — known=1 server_time=... [READER DEGRADED]
Reader reconnected: fsm: Credential reader recovered — resuming polling → server_comm: Credential reader recovered — heartbeats nominal → subsequent heartbeats: server_comm: Heartbeat OK — known=1 server_time=... (no suffix)