### PR TITLE
gated TLS and added response signing

### DIFF
--- a/access_module/components/portunus_config/include/security_config.hpp
+++ b/access_module/components/portunus_config/include/security_config.hpp
@@ -2,16 +2,19 @@
  * @file security_config.h
  * @brief Security configuration constants for the Portunus access module.
  *
- * Two complementary mechanisms protect server communication:
+ * Two mechanisms protect server communication:
  *
- *   1. TLS (HTTPS) — channel-level encryption via mbedTLS / ESP-IDF cert bundle.
- *      Prevents eavesdropping and MITM attacks on the network.
+ *   1. TLS (HTTPS) — mandatory for ACCESS_POINT builds.  A door image cannot
+ *      be compiled without TLS; the #error gate in server_comm.cpp enforces
+ *      this, and the Kconfig dependency prevents menuconfig from allowing the
+ *      combination.  TLS authenticates the server and encrypts the channel.
  *      Enabled by CONFIG_PORTUNUS_USE_TLS (Kconfig).
  *
- *   2. HMAC-SHA256 request signing — application-level message authentication.
- *      Every outbound POST includes an X-Portunus-Sig header containing
- *      HMAC-SHA256(pre_shared_key, request_body_bytes).
- *      The server rejects any request whose signature does not match.
+ *   2. HMAC-SHA256 message authentication — belt-and-suspenders on top of TLS,
+ *      not a TLS replacement.  Applied to both outbound requests (X-Portunus-Sig
+ *      header) and inbound access responses (server signs the response; device
+ *      verifies before publishing EVENT_ACCESS_GRANTED).  A door grant without
+ *      a valid response signature is treated as a deny.
  *      Enabled by CONFIG_PORTUNUS_HMAC_ENABLED (Kconfig).
  *
  * Key management notes:

--- a/access_module/main/Kconfig.projbuild
+++ b/access_module/main/Kconfig.projbuild
@@ -17,6 +17,7 @@ menu "Portunus Configuration"
 
             config PORTUNUS_MODULE_TYPE_ACCESS_POINT
                 bool "Access point (door control)"
+                depends on PORTUNUS_USE_TLS
                 imply PORTUNUS_ENABLE_DOOR_STRIKE
 
             config PORTUNUS_MODULE_TYPE_PROVISIONING_CONSOLE

--- a/access_module/services/grpc_client/include/grpc_client.hpp
+++ b/access_module/services/grpc_client/include/grpc_client.hpp
@@ -136,6 +136,10 @@ bool grpc_client_is_connected(grpc_client_handle_t handle);
  * @param resp_cap       Capacity of resp_buf in bytes.
  * @param resp_len       [out] Actual protobuf bytes written to resp_buf.
  * @param grpc_status    [out] gRPC status code from trailers (0 = OK).
+ * @param out_sig_hex    [out] If non-NULL, receives the NUL-terminated hex-encoded
+ *                       x-portunus-sig trailer value (PORTUNUS_HMAC_HEX_LEN bytes).
+ *                       Zero-filled on entry; left empty if the server did not
+ *                       send the header.  Pass NULL to ignore.
  *
  * @return PORTUNUS_OK        Round-trip succeeded (check grpc_status for app errors).
  *         PORTUNUS_ERR_HTTP_CONNECT  Could not establish connection.
@@ -147,7 +151,8 @@ portunus_err_t grpc_client_unary_call(grpc_client_handle_t handle,
                                        const char *service_method,
                                        const uint8_t *req_buf, size_t req_len,
                                        uint8_t *resp_buf, size_t resp_cap,
-                                       int *resp_len, int *grpc_status);
+                                       int *resp_len, int *grpc_status,
+                                       char *out_sig_hex);
 
 /**
  * @brief Send an HTTP/2 PING and wait for the ACK (B18).

--- a/access_module/services/grpc_client/src/grpc_client.cpp
+++ b/access_module/services/grpc_client/src/grpc_client.cpp
@@ -80,6 +80,9 @@ struct stream_state_t {
     bool     stream_closed;      /**< True after stream is fully closed. */
     bool     got_error;          /**< True if an error occurred during the stream. */
     uint32_t stream_error_code;  /**< HTTP/2 RST_STREAM error code (0 = clean close). */
+
+    /* Response HMAC (x-portunus-sig trailer from server) */
+    char     resp_sig_hex[65];   /**< NUL-terminated hex-encoded signature, or empty. */
 };
 
 /** Main client structure (opaque to callers). */
@@ -252,6 +255,15 @@ static int cb_on_header(nghttp2_session *session,
         size_t copy_len = valuelen < sizeof(status_str) - 1 ? valuelen : sizeof(status_str) - 1;
         memcpy(status_str, value, copy_len);
         ss->grpc_status = atoi(status_str);
+    }
+
+    /* Capture the response HMAC signature trailer from the server. */
+    if (namelen == 14 && memcmp(name, "x-portunus-sig", 14) == 0) {
+        size_t copy_len = valuelen < sizeof(ss->resp_sig_hex) - 1
+                          ? valuelen
+                          : sizeof(ss->resp_sig_hex) - 1;
+        memcpy(ss->resp_sig_hex, value, copy_len);
+        ss->resp_sig_hex[copy_len] = '\0';
     }
 
     /* Log :status for debugging. */
@@ -727,7 +739,8 @@ portunus_err_t grpc_client_unary_call(grpc_client_handle_t c,
                                        const char *service_method,
                                        const uint8_t *req_buf, size_t req_len,
                                        uint8_t *resp_buf, size_t resp_cap,
-                                       int *resp_len, int *grpc_status)
+                                       int *resp_len, int *grpc_status,
+                                       char *out_sig_hex)
 {
     if (c == nullptr || service_method == nullptr || req_buf == nullptr ||
         resp_buf == nullptr || resp_len == nullptr || grpc_status == nullptr) {
@@ -882,6 +895,13 @@ portunus_err_t grpc_client_unary_call(grpc_client_handle_t c,
 
     ESP_LOGD(TAG, "gRPC call %s complete: status=%d, response=%d bytes",
              service_method, *grpc_status, *resp_len);
+
+    /* Propagate the response signature trailer to the caller. */
+    if (out_sig_hex != nullptr) {
+        size_t sig_len = strnlen(ss.resp_sig_hex, sizeof(ss.resp_sig_hex));
+        memcpy(out_sig_hex, ss.resp_sig_hex, sig_len);
+        out_sig_hex[sig_len] = '\0';
+    }
 
     return PORTUNUS_OK;
 }

--- a/access_module/services/server_comm/src/server_comm.cpp
+++ b/access_module/services/server_comm/src/server_comm.cpp
@@ -38,6 +38,18 @@
   #include "mbedtls/sha256.h"
 #endif
 
+/* ACCESS_POINT builds must use TLS: the response carries a door-grant decision
+ * that is only authenticated at the application layer (HMAC) when TLS is also
+ * present.  Without TLS, any on-path device can forge a granted=true response
+ * even with HMAC fully enabled for outbound requests. */
+#ifdef CONFIG_PORTUNUS_MODULE_TYPE_ACCESS_POINT
+  #if !PORTUNUS_USE_TLS
+    #error "ACCESS_POINT firmware cannot be built without TLS (CONFIG_PORTUNUS_USE_TLS). " \
+           "A door image without TLS has no authenticated server-to-device channel. " \
+           "Enable TLS in menuconfig → Security Configuration."
+  #endif
+#endif
+
 /* TLS / HMAC */
 #if PORTUNUS_USE_TLS
   #if PORTUNUS_TLS_USE_CUSTOM_CA
@@ -144,6 +156,20 @@ static bool compute_hmac_hex(const uint8_t *data, size_t data_len,
     out_hex[64] = '\0';
     return true;
 }
+/**
+ * @brief Constant-time comparison of two 64-char hex HMAC strings.
+ *
+ * Runs all 64 iterations regardless of the first mismatch to avoid
+ * leaking timing information about partial matches.
+ */
+static bool sig_hex_equal(const char *a, const char *b)
+{
+    uint8_t diff = 0;
+    for (int i = 0; i < 64; ++i) {
+        diff |= static_cast<uint8_t>(a[i]) ^ static_cast<uint8_t>(b[i]);
+    }
+    return diff == 0;
+}
 #endif /* PORTUNUS_HMAC_ENABLED */
 
 /* ── Forward declarations ──────────────────────────────────────────────────── */
@@ -213,6 +239,9 @@ static bool get_rssi(int32_t *out)
  * @param resp_cap       Capacity of resp_buf
  * @param resp_len       [out] Actual protobuf bytes written to resp_buf
  * @param grpc_status    [out] gRPC status code (0 = OK)
+ * @param out_sig_hex    [out] If non-NULL, receives the x-portunus-sig trailer
+ *                       from the server response (PORTUNUS_HMAC_HEX_LEN bytes).
+ *                       Pass NULL for RPCs that do not need response verification.
  *
  * @return PORTUNUS_OK on successful round-trip.
  */
@@ -220,7 +249,8 @@ static portunus_err_t grpc_post_proto(const char *method,
                                        const uint8_t *req_buf, size_t req_len,
                                        const char *sig_projection,
                                        uint8_t *resp_buf, size_t resp_cap,
-                                       int *resp_len, int *grpc_status)
+                                       int *resp_len, int *grpc_status,
+                                       char *out_sig_hex)
 {
 #if PORTUNUS_HMAC_ENABLED
     /* Sign the canonical projection string, not the raw protobuf bytes.
@@ -241,10 +271,34 @@ static portunus_err_t grpc_post_proto(const char *method,
     return grpc_client_unary_call(s_grpc_handle, method,
                                   req_buf, req_len,
                                   resp_buf, resp_cap,
-                                  resp_len, grpc_status);
+                                  resp_len, grpc_status,
+                                  out_sig_hex);
 }
 
 #else /* !PORTUNUS_USE_GRPC — HTTP/1.1 path */
+
+#if PORTUNUS_HMAC_ENABLED
+/** Context passed to the esp_http_client event handler to capture the
+ *  X-Portunus-Sig response header from the server. */
+struct http_resp_ctx_t {
+    char sig_hex[PORTUNUS_HMAC_HEX_LEN];
+};
+
+static esp_err_t s_http_event_handler(esp_http_client_event_t *evt)
+{
+    if (evt->event_id != HTTP_EVENT_ON_HEADER) { return ESP_OK; }
+    auto *ctx = static_cast<http_resp_ctx_t *>(evt->user_data);
+    if (ctx == nullptr) { return ESP_OK; }
+    if (strcasecmp(evt->header_key, PORTUNUS_HMAC_HEADER_NAME) == 0 &&
+        evt->header_value != nullptr) {
+        size_t len = strlen(evt->header_value);
+        if (len > PORTUNUS_HMAC_HEX_LEN - 1) { len = PORTUNUS_HMAC_HEX_LEN - 1; }
+        memcpy(ctx->sig_hex, evt->header_value, len);
+        ctx->sig_hex[len] = '\0';
+    }
+    return ESP_OK;
+}
+#endif /* PORTUNUS_HMAC_ENABLED */
 
 /**
  * @brief POST a protobuf-encoded buffer to url, read the response into
@@ -255,6 +309,8 @@ static portunus_err_t grpc_post_proto(const char *method,
  *   • Validates the server certificate via the ESP-IDF Mozilla CA bundle
  *     unless PORTUNUS_TLS_SKIP_VERIFY is set (dev only).
  *   • Adds X-Portunus-Sig HMAC-SHA256 header when PORTUNUS_HMAC_ENABLED.
+ *   • When out_sig_hex is non-NULL and HMAC is enabled, captures the
+ *     server's X-Portunus-Sig response header for caller verification.
  *
  * @param url        Full URL (e.g. "https://192.168.1.100:8443/v1/heartbeat")
  * @param req_buf    Encoded protobuf request body
@@ -263,18 +319,32 @@ static portunus_err_t grpc_post_proto(const char *method,
  * @param resp_cap   Capacity of resp_buf
  * @param resp_len   [out] Actual bytes written to resp_buf
  * @param http_status [out] HTTP status code
+ * @param out_sig_hex [out] If non-NULL and HMAC is enabled, receives the
+ *                    server's X-Portunus-Sig response header value
+ *                    (PORTUNUS_HMAC_HEX_LEN bytes, NUL-terminated).
  *
  * @return PORTUNUS_OK on successful round-trip (even if http_status != 200).
  */
 static portunus_err_t http_post_proto(const char *url,
                                       const uint8_t *req_buf, size_t req_len,
                                       uint8_t *resp_buf, size_t resp_cap,
-                                      int *resp_len, int *http_status)
+                                      int *resp_len, int *http_status,
+                                      char *out_sig_hex)
 {
     esp_http_client_config_t cfg = {};
     cfg.url         = url;
     cfg.timeout_ms  = PORTUNUS_SERVER_REQUEST_TIMEOUT_MS;
     cfg.disable_auto_redirect = true;
+
+#if PORTUNUS_HMAC_ENABLED
+    http_resp_ctx_t resp_ctx = {};
+    if (out_sig_hex != nullptr) {
+        cfg.event_handler = s_http_event_handler;
+        cfg.user_data     = &resp_ctx;
+    }
+#else
+    (void)out_sig_hex;
+#endif
 
 #if PORTUNUS_USE_TLS
   #if PORTUNUS_TLS_SKIP_VERIFY
@@ -353,6 +423,14 @@ static portunus_err_t http_post_proto(const char *url,
         if ((size_t)total_read >= resp_cap) { break; }
     }
     *resp_len = total_read;
+
+#if PORTUNUS_HMAC_ENABLED
+    if (out_sig_hex != nullptr) {
+        size_t sig_len = strnlen(resp_ctx.sig_hex, sizeof(resp_ctx.sig_hex));
+        memcpy(out_sig_hex, resp_ctx.sig_hex, sig_len);
+        out_sig_hex[sig_len] = '\0';
+    }
+#endif
 
     esp_http_client_close(client);
     esp_http_client_cleanup(client);
@@ -471,7 +549,7 @@ static void handle_heartbeat(const event_heartbeat_t *hb)
         req_buf, ostream.bytes_written,
         proj,
         resp_buf, sizeof(resp_buf),
-        &resp_len, &grpc_status);
+        &resp_len, &grpc_status, nullptr);
     if (err != PORTUNUS_OK) {
         ESP_LOGW(TAG, "Heartbeat gRPC failed: err=0x%04x", (unsigned)err);
         return;
@@ -485,7 +563,7 @@ static void handle_heartbeat(const event_heartbeat_t *hb)
     portunus_err_t err = http_post_proto(s_heartbeat_url,
                                          req_buf, ostream.bytes_written,
                                          resp_buf, sizeof(resp_buf),
-                                         &resp_len, &status);
+                                         &resp_len, &status, nullptr);
     if (err != PORTUNUS_OK) {
         ESP_LOGW(TAG, "Heartbeat HTTP failed: err=0x%04x", (unsigned)err);
         return;
@@ -538,6 +616,12 @@ static void handle_credential(const event_credential_read_t *cred)
     /* POST */
     uint8_t resp_buf[portunus_v1_AccessResponse_size + 16];
     int resp_len = 0;
+#if PORTUNUS_HMAC_ENABLED
+    char resp_sig_hex[PORTUNUS_HMAC_HEX_LEN] = {};
+    char *p_resp_sig = resp_sig_hex;
+#else
+    char *p_resp_sig = nullptr;
+#endif
 
 #if PORTUNUS_USE_GRPC
     char proj[128];
@@ -548,7 +632,7 @@ static void handle_credential(const event_credential_read_t *cred)
         req_buf, ostream.bytes_written,
         proj,
         resp_buf, sizeof(resp_buf),
-        &resp_len, &grpc_status);
+        &resp_len, &grpc_status, p_resp_sig);
     if (err != PORTUNUS_OK) {
         ESP_LOGW(TAG, "Access gRPC failed: err=0x%04x", (unsigned)err);
         publish_access_denied(req_log_id, "grpc_error");
@@ -564,7 +648,7 @@ static void handle_credential(const event_credential_read_t *cred)
     portunus_err_t err = http_post_proto(s_access_url,
                                          req_buf, ostream.bytes_written,
                                          resp_buf, sizeof(resp_buf),
-                                         &resp_len, &status);
+                                         &resp_len, &status, p_resp_sig);
     if (err != PORTUNUS_OK) {
         ESP_LOGW(TAG, "Access HTTP failed: err=0x%04x", (unsigned)err);
         publish_access_denied(req_log_id, "http_error");
@@ -586,6 +670,31 @@ static void handle_credential(const event_credential_read_t *cred)
         publish_access_denied(req_log_id, "decode_error");
         return;
     }
+
+#if PORTUNUS_HMAC_ENABLED
+    /* Verify the server's response signature before acting on the decision.
+     * Projection: "access|{module_id}|{credential_id}|{0 or 1}" — must match
+     * AccessResponseProjection() in server/internal/grpcapi/interceptors.go. */
+    if (resp_sig_hex[0] == '\0') {
+        ESP_LOGE(TAG, "Access response missing X-Portunus-Sig — denying");
+        publish_access_denied(req_log_id, "missing_response_sig");
+        return;
+    }
+    char resp_proj[128];
+    snprintf(resp_proj, sizeof(resp_proj), "access|%s|%s|%d",
+             req.module_id, req.credential_id, resp.granted ? 1 : 0);
+    char expected_sig[PORTUNUS_HMAC_HEX_LEN];
+    if (!compute_hmac_hex((const uint8_t *)resp_proj, strlen(resp_proj), expected_sig)) {
+        ESP_LOGE(TAG, "HMAC compute failed during response verify");
+        publish_access_denied(req_log_id, "sig_compute_error");
+        return;
+    }
+    if (!sig_hex_equal(resp_sig_hex, expected_sig)) {
+        ESP_LOGE(TAG, "Access response HMAC mismatch — denying");
+        publish_access_denied(req_log_id, "invalid_response_sig");
+        return;
+    }
+#endif /* PORTUNUS_HMAC_ENABLED */
 
     ESP_LOGI(TAG, "Access decision — id=%s granted=%d reason=%s known=%d",
              req_log_id, resp.granted, resp.reason, resp.known);
@@ -676,7 +785,7 @@ static void handle_provision(const event_provision_request_t *req)
         req_buf, ostream.bytes_written,
         proj,
         resp_buf, sizeof(resp_buf),
-        &resp_len, &grpc_status);
+        &resp_len, &grpc_status, nullptr);
     if (err != PORTUNUS_OK) {
         ESP_LOGW(TAG, "Provision gRPC failed: 0x%04x", (unsigned)err);
         publish_provision_result(PROVISION_RESULT_COMM_ERROR, NULL, "grpc_error");
@@ -692,7 +801,7 @@ static void handle_provision(const event_provision_request_t *req)
     portunus_err_t err = http_post_proto(s_provision_url,
                                          req_buf, ostream.bytes_written,
                                          resp_buf, sizeof(resp_buf),
-                                         &resp_len, &http_status);
+                                         &resp_len, &http_status, nullptr);
     if (err != PORTUNUS_OK) {
         ESP_LOGW(TAG, "Provision HTTP failed: 0x%04x", (unsigned)err);
         publish_provision_result(PROVISION_RESULT_COMM_ERROR, NULL, "http_error");

--- a/server/cmd/portunus-server/main.go
+++ b/server/cmd/portunus-server/main.go
@@ -228,6 +228,7 @@ func main() {
 			HeartbeatService: heartbeatSvc,
 			AccessService:    accessSvc,
 			ProvisionService: provisionSvc,
+			HMACSecret:       cfg.HMACSecret,
 		})
 		pb.RegisterPortunusServiceServer(grpcServer, grpcHandler)
 		if cfg.Env != config.EnvProd {

--- a/server/internal/grpcapi/interceptors.go
+++ b/server/internal/grpcapi/interceptors.go
@@ -47,6 +47,31 @@ func hmacProjection(req interface{}) ([]byte, error) {
 	}
 }
 
+// accessResponseProjection returns the canonical string the server signs for an
+// AccessResponse and the device verifies before publishing EVENT_ACCESS_GRANTED.
+// Format: "access|{module_id}|{credential_id}|{1 or 0}"
+// Must match the snprintf in handle_credential() in server_comm.cpp.
+func accessResponseProjection(moduleID, credentialID string, granted bool) []byte {
+	v := 0
+	if granted {
+		v = 1
+	}
+	return []byte(fmt.Sprintf("access|%s|%s|%d", moduleID, credentialID, v))
+}
+
+// AccessResponseSig computes the HMAC-SHA256 signature the server attaches to
+// an AccessResponse.  Returns an empty string when secret is empty (HMAC
+// disabled), so callers can gate on a non-empty result.
+func AccessResponseSig(secret, moduleID, credentialID string, granted bool) string {
+	if secret == "" {
+		return ""
+	}
+	projection := accessResponseProjection(moduleID, credentialID, granted)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(projection)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
 // HMACInterceptor returns a gRPC unary server interceptor that verifies
 // the HMAC-SHA256 signature attached as custom metadata by the ESP32.
 //

--- a/server/internal/grpcapi/server.go
+++ b/server/internal/grpcapi/server.go
@@ -22,7 +22,9 @@ import (
 	"github.com/BrandonDHaskell/Portunus/server/internal/pbconvert"
 	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/service"
 	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/types"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -32,6 +34,11 @@ type Dependencies struct {
 	HeartbeatService *service.HeartbeatService
 	AccessService    *service.AccessService
 	ProvisionService *service.ProvisionService
+	// HMACSecret is the pre-shared key used to sign AccessResponse messages.
+	// When non-empty the server attaches an x-portunus-sig trailing metadata
+	// entry so the device can verify the response before acting on it.
+	// Must match CONFIG_PORTUNUS_HMAC_SECRET in the firmware.
+	HMACSecret string
 }
 
 // Server implements pb.PortunusServiceServer.
@@ -42,6 +49,7 @@ type Server struct {
 	heartbeatService *service.HeartbeatService
 	accessService    *service.AccessService
 	provisionService *service.ProvisionService
+	hmacSecret       string
 }
 
 // NewServer creates a gRPC server handler that delegates to the service layer.
@@ -51,6 +59,7 @@ func NewServer(d Dependencies) *Server {
 		heartbeatService: d.HeartbeatService,
 		accessService:    d.AccessService,
 		provisionService: d.ProvisionService,
+		hmacSecret:       d.HMACSecret,
 	}
 }
 
@@ -122,14 +131,20 @@ func (s *Server) RequestAccess(ctx context.Context, req *pb.AccessRequest) (*pb.
 		}
 	}
 
-	return &pb.AccessResponse{
+	pbResp := &pb.AccessResponse{
 		Ok:         resp.OK,
 		Known:      resp.Known,
 		Granted:    resp.Granted,
 		Reason:     resp.Reason,
 		ModuleId:   resp.ModuleID,
 		ServerTime: resp.ServerTime,
-	}, nil
+	}
+
+	if sig := AccessResponseSig(s.hmacSecret, domainReq.ModuleID, domainReq.CredentialID, resp.Granted); sig != "" {
+		grpc.SetTrailer(ctx, metadata.Pairs(hmacHeaderKey, sig))
+	}
+
+	return pbResp, nil
 }
 
 // ─── Provision ──────────────────────────────────────────────────────────────

--- a/server/internal/httpapi/server.go
+++ b/server/internal/httpapi/server.go
@@ -2,9 +2,13 @@ package httpapi
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -54,6 +58,7 @@ type Server struct {
 	moduleAuthService    *service.ModuleAuthorizationService
 	auditStore           store.AuditStore
 	credentialHashSecret []byte
+	hmacSecret           string
 	tlsEnabled           bool
 }
 
@@ -74,6 +79,7 @@ func NewServer(d Dependencies) *Server {
 		moduleAuthService:    d.ModuleAuthService,
 		auditStore:           d.AuditStore,
 		credentialHashSecret: d.CredentialHashSecret,
+		hmacSecret:           d.HMACSecret,
 		tlsEnabled:           d.TLSEnabled,
 	}
 
@@ -335,6 +341,17 @@ func (s *Server) handleAccessRequest(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusInternalServerError, "internal_error", "unexpected server error")
 			return
 		}
+	}
+
+	if s.hmacSecret != "" {
+		v := 0
+		if resp.Granted {
+			v = 1
+		}
+		proj := fmt.Sprintf("access|%s|%s|%d", req.ModuleID, req.CredentialID, v)
+		mac := hmac.New(sha256.New, []byte(s.hmacSecret))
+		mac.Write([]byte(proj))
+		w.Header().Set("X-Portunus-Sig", hex.EncodeToString(mac.Sum(nil)))
 	}
 
 	if !resp.Known {


### PR DESCRIPTION
Piece 1 — compile-time gate (both forms):

Kconfig.projbuild:19 — depends on PORTUNUS_USE_TLS added to the PORTUNUS_MODULE_TYPE_ACCESS_POINT choice entry. menuconfig will grey out the ACCESS_POINT variant if TLS is disabled.
server_comm.cpp:42-52 — #error preprocessor guard. If someone bypasses Kconfig (e.g., manual sdkconfig edit), the build fails with an explanatory message.
Piece 2 — response signing:

Server — gRPC:

interceptors.go — accessResponseProjection and AccessResponseSig added. Projection format: "access|{module_id}|{credential_id}|{0 or 1}".
grpcapi/server.go — HMACSecret threaded through Dependencies → Server. RequestAccess calls AccessResponseSig and attaches the result as gRPC trailing metadata (x-portunus-sig).
Server — HTTP:

httpapi/server.go — hmacSecret stored on Server. handleAccessRequest computes the same projection inline and sets X-Portunus-Sig response header before writing the body.
main.go: main.go — HMACSecret: cfg.HMACSecret passed to grpcapi.NewServer.

Firmware — gRPC client:

grpc_client.hpp — out_sig_hex parameter added to grpc_client_unary_call.
grpc_client.cpp — stream_state_t gains resp_sig_hex[65]; cb_on_header captures the x-portunus-sig trailer; grpc_client_unary_call copies it to out_sig_hex.
Firmware — server_comm:

server_comm.cpp — http_post_proto gains an event handler that captures X-Portunus-Sig from response headers; grpc_post_proto passes out_sig_hex through. handle_credential verifies the response HMAC (constant-time sig_hex_equal) before publishing EVENT_ACCESS_GRANTED — a missing or mismatched sig is a deny. Heartbeat and provision pass nullptr and are unaffected.

security_config.hpp — comment corrected: TLS is now mandatory for ACCESS_POINT, and HMAC is belt-and-suspenders on top of it, not a substitute.