### PR TITLE
Fix/minor security risk mitigation

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -237,6 +237,7 @@ tasks:
     cmds:
       - |
         eval "$({{.IDF_PYTHON}} {{.IDF_PATH}}/tools/idf_tools.py export 2>/dev/null)"
+        rm -f sdkconfig
         DEFAULTS="sdkconfig.defaults"
         [ -f sdkconfig.defaults.local ] && DEFAULTS="${DEFAULTS};sdkconfig.defaults.local"
         DEFAULTS="${DEFAULTS};sdkconfig.defaults.dev"

--- a/access_module/components/portunus_config/include/security_config.hpp
+++ b/access_module/components/portunus_config/include/security_config.hpp
@@ -89,6 +89,13 @@ extern "C" {
   #define PORTUNUS_HMAC_SECRET  CONFIG_PORTUNUS_HMAC_SECRET
 #endif
 
+#if PORTUNUS_HMAC_ENABLED
+  /* sizeof(string literal) includes the NUL, so an empty secret is sizeof == 1. */
+  _Static_assert(sizeof(PORTUNUS_HMAC_SECRET) > 1,
+                 "PORTUNUS_HMAC_ENABLED is set but PORTUNUS_HMAC_SECRET is empty. "
+                 "Set CONFIG_PORTUNUS_HMAC_SECRET (openssl rand -hex 32) or disable HMAC.");
+#endif
+
 /** HTTP header name for the HMAC signature. */
 #define PORTUNUS_HMAC_HEADER_NAME  "X-Portunus-Sig"
 

--- a/access_module/core/provisioning_fsm/src/provisioning_fsm.cpp
+++ b/access_module/core/provisioning_fsm/src/provisioning_fsm.cpp
@@ -436,9 +436,12 @@ void ProvisioningFSM::publish_capture_request(const event_credential_read_t *cre
     memset(&evt, 0, sizeof(evt));
     evt.id = EVENT_PROVISION_REQUEST;
 
-    memcpy(evt.payload.provision_request.credential_uid,
-           cred->credential.uid, cred->credential.uid_len);
-    evt.payload.provision_request.credential_uid_len = cred->credential.uid_len;
+    size_t uid_n = cred->credential.uid_len;
+    if (uid_n > sizeof(evt.payload.provision_request.credential_uid)) {
+        uid_n = sizeof(evt.payload.provision_request.credential_uid);
+    }
+    memcpy(evt.payload.provision_request.credential_uid, cred->credential.uid, uid_n);
+    evt.payload.provision_request.credential_uid_len = (uint8_t)uid_n;
 
     event_bus_publish(&evt);
 }

--- a/access_module/core/system_fsm/src/system_fsm.cpp
+++ b/access_module/core/system_fsm/src/system_fsm.cpp
@@ -385,8 +385,14 @@ void SystemFSM::poll_reed_switch()
              */
             if (m_strike_energized) {
                 ESP_LOGI(TAG, "Door closed during unlock hold — re-locking early");
-                m_access->lock();
-                cancel_unlock_timer();
+                portunus_err_t lock_err = m_access->lock();
+                if (lock_err != PORTUNUS_OK) {
+                    ESP_LOGE(TAG, "Early re-lock failed (0x%" PRIx32 ") — timer will retry",
+                             (uint32_t)lock_err);
+                    /* Leave timer running so check_unlock_timer retries on next tick. */
+                } else {
+                    cancel_unlock_timer();
+                }
             }
         }
 
@@ -414,7 +420,12 @@ void SystemFSM::check_unlock_timer()
         ESP_LOGI(TAG, "Unlock hold timer expired — re-locking");
 
         if (m_caps.has_access_point) {
-            m_access->lock();
+            portunus_err_t lock_err = m_access->lock();
+            if (lock_err != PORTUNUS_OK) {
+                ESP_LOGE(TAG, "Re-lock after timer expiry failed (0x%" PRIx32 ") — will retry",
+                         (uint32_t)lock_err);
+                return; /* Leave timer expired so next tick retries. */
+            }
         }
         cancel_unlock_timer();
 

--- a/access_module/drivers/access_point_gpio/src/door_strike.cpp
+++ b/access_module/drivers/access_point_gpio/src/door_strike.cpp
@@ -71,7 +71,11 @@ portunus_err_t door_strike_init(void)
 
 portunus_err_t door_strike_energize(void)
 {
-    gpio_set_level(static_cast<gpio_num_t>(PIN_DOOR_STRIKE), STRIKE_LEVEL_ACTIVE);
+    esp_err_t err = gpio_set_level(static_cast<gpio_num_t>(PIN_DOOR_STRIKE), STRIKE_LEVEL_ACTIVE);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Strike energize gpio_set_level failed: %s", esp_err_to_name(err));
+        return PORTUNUS_ERR_GPIO_INIT;
+    }
     s_energized = true;
     ESP_LOGI(TAG, "Strike ENERGIZED (unlocked)");
     return PORTUNUS_OK;
@@ -79,7 +83,19 @@ portunus_err_t door_strike_energize(void)
 
 portunus_err_t door_strike_deenergize(void)
 {
-    gpio_set_level(static_cast<gpio_num_t>(PIN_DOOR_STRIKE), STRIKE_LEVEL_INACTIVE);
+    esp_err_t err = gpio_set_level(static_cast<gpio_num_t>(PIN_DOOR_STRIKE), STRIKE_LEVEL_INACTIVE);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Strike de-energize gpio_set_level failed: %s", esp_err_to_name(err));
+        return PORTUNUS_ERR_GPIO_INIT;
+    }
+    /* Readback the output register to confirm the write landed. */
+    int readback = gpio_get_level(static_cast<gpio_num_t>(PIN_DOOR_STRIKE));
+    if (readback != STRIKE_LEVEL_INACTIVE) {
+        ESP_LOGE(TAG, "Strike de-energize readback mismatch: expected %d got %d — door may be unlocked",
+                 STRIKE_LEVEL_INACTIVE, readback);
+        s_energized = true; /* reflect actual hardware state */
+        return PORTUNUS_ERR_GPIO_INIT;
+    }
     s_energized = false;
     ESP_LOGI(TAG, "Strike DE-ENERGIZED (locked)");
     return PORTUNUS_OK;

--- a/access_module/services/server_comm/src/server_comm.cpp
+++ b/access_module/services/server_comm/src/server_comm.cpp
@@ -654,8 +654,12 @@ static void handle_provision(const event_provision_request_t *req)
             sizeof(pb_req.module_id) - 1);
 
     /* New member card UID — server applies HMAC-SHA256 before storing. */
-    pb_req.credential_uid.size = req->credential_uid_len;
-    memcpy(pb_req.credential_uid.bytes, req->credential_uid, req->credential_uid_len);
+    size_t uid_n = req->credential_uid_len;
+    if (uid_n > sizeof(pb_req.credential_uid.bytes)) {
+        uid_n = sizeof(pb_req.credential_uid.bytes);
+    }
+    pb_req.credential_uid.size = (pb_size_t)uid_n;
+    memcpy(pb_req.credential_uid.bytes, req->credential_uid, uid_n);
 
     /* Encode */
     uint8_t req_buf[portunus_v1_ProvisionCredentialRequest_size];


### PR DESCRIPTION
Both sites clamped. The current MFRC522 driver can never produce uid_len > 7, so behavior is unchanged today — but a future PN532 driver with a 10-byte cascade-3 UID (or any other reader swap) won't silently overflow either buffer.

firmware:build:dev now starts from a clean slate just like firmware:build:prod. A stale sdkconfig left over from a previous dev (or menuconfig) session can no longer silently carry ESP_TLS_INSECURE into the next build, regardless of how the build is invoked.

door_strike.cpp: door_strike_energize() now checks the gpio_set_level() return and returns an error on failure. door_strike_deenergize() does the same, plus reads back the output register after a successful write — if the readback doesn't match STRIKE_LEVEL_INACTIVE, it logs an ESP_LOGE (the "alarm"), resets s_energized to reflect actual state, and returns an error. This is the only function in the codebase that can leave a door physically unlocked silently.

system_fsm.cpp (two sites): Both lock() call sites now check the return value. On failure, the unlock timer is left running rather than cancelled, so the next check_unlock_timer tick automatically retries — no explicit retry state needed.