### PR TITLE
fixed security findings after AI audit

### DIFF
--- a/server/.env.ci
+++ b/server/.env.ci
@@ -8,3 +8,8 @@ PORTUNUS_DB_PATH=:memory:
 # TLS cert/key intentionally unset: the ci profile generates an ephemeral
 # self-signed cert in-process (config.EphemeralCert), so CI runs the same TLS
 # handshake path as prod with nothing on disk and nothing to rotate.
+
+# Credential hash secret intentionally unset in CI (no committed secrets).
+# The explicit override below acknowledges that CI uses reversible SHA-256 hashes.
+# Never set this in a production or production-like environment.
+PORTUNUS_ALLOW_UNKEYED_CREDENTIAL_HASH=true

--- a/server/cmd/portunus-server/main.go
+++ b/server/cmd/portunus-server/main.go
@@ -7,6 +7,8 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -22,6 +24,7 @@ import (
 	"github.com/BrandonDHaskell/Portunus/server/internal/db"
 	"github.com/BrandonDHaskell/Portunus/server/internal/grpcapi"
 	"github.com/BrandonDHaskell/Portunus/server/internal/httpapi"
+	"github.com/BrandonDHaskell/Portunus/server/internal/replay"
 	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/service"
 
 	sqlitestore "github.com/BrandonDHaskell/Portunus/server/internal/portunus/store/sqlite"
@@ -87,7 +90,13 @@ func main() {
 
 	credentialHashSecret := []byte(cfg.CredentialHashSecret)
 	if cfg.CredentialHashSecret == "" {
-		logger.Printf("WARNING: PORTUNUS_CREDENTIAL_HASH_SECRET not set — credential IDs hashed without a key (insecure, dev only)")
+		if !cfg.AllowUnkeyedCredentialHash {
+			logger.Fatalf("PORTUNUS_CREDENTIAL_HASH_SECRET is not set. " +
+				"Starting without a key stores reversible credential hashes. " +
+				"Set PORTUNUS_CREDENTIAL_HASH_SECRET or, for dev/test only, " +
+				"set PORTUNUS_ALLOW_UNKEYED_CREDENTIAL_HASH=true to override.")
+		}
+		logger.Printf("WARNING: PORTUNUS_CREDENTIAL_HASH_SECRET not set — credential IDs hashed without a key (INSECURE, dev/test only)")
 	}
 	accessSvc.SetCredentialHashSecret(credentialHashSecret)
 	accessSvc.SetLogger(logger)
@@ -119,6 +128,11 @@ func main() {
 
 	// Auth service: session-based admin authentication.
 	authSvc := service.NewAuthService(adminUserStore, sessionStore, roleStore, logger)
+	// Write the first-run admin password to a private file instead of the log
+	// stream (F-9).  Skip for in-memory DBs used in dev/test.
+	if cfg.DBPath != ":memory:" && !strings.Contains(cfg.DBPath, "mode=memory") {
+		authSvc.SetBootstrapPasswordFile(filepath.Join(filepath.Dir(cfg.DBPath), "initial-admin-password.txt"))
+	}
 	if err := authSvc.Bootstrap(ctx); err != nil {
 		logger.Fatalf("auth bootstrap error: %v", err)
 	}
@@ -126,6 +140,18 @@ func main() {
 	// Admin user and role management services.
 	adminUserSvc := service.NewAdminUserService(adminUserStore, roleStore, auditStore)
 	roleSvc := service.NewRoleService(roleStore)
+
+	// Session sweeper: cleans up expired session rows hourly (F-11).
+	sessionSweeper := service.NewSessionSweeper(sessionStore, time.Hour, logger)
+	sessionSweeper.Start(ctx)
+	defer sessionSweeper.Stop()
+
+	// Shared replay store: one namespace for HTTP and gRPC so a nonce cannot be
+	// replayed across transports (F-3).  Only allocated when HMAC is enabled.
+	var sharedReplayStore *replay.Store
+	if cfg.HMACSecret != "" {
+		sharedReplayStore = replay.NewStore(60 * time.Second)
+	}
 
 	// Acquire the serving certificate once. prod loads it from PEM files; ci
 	// generates an ephemeral self-signed cert in-process. Both the HTTP and the
@@ -163,6 +189,7 @@ func main() {
 		ModuleAuthService:    moduleAuthSvc,
 		AuditStore:           auditStore,
 		HMACSecret:           cfg.HMACSecret,
+		ReplayStore:          sharedReplayStore,
 		CredentialHashSecret: credentialHashSecret,
 		TLSEnabled:           tlsEnabled,
 	})
@@ -191,8 +218,7 @@ func main() {
 			grpcapi.LoggingInterceptor(logger),
 		}
 		if cfg.HMACSecret != "" {
-			replayStore := grpcapi.NewReplayStore(60 * time.Second)
-			interceptors = append(interceptors, grpcapi.HMACInterceptor(cfg.HMACSecret, replayStore))
+			interceptors = append(interceptors, grpcapi.HMACInterceptor(cfg.HMACSecret, sharedReplayStore))
 			logger.Printf("gRPC HMAC auth: ENABLED (replay window: 60s)")
 		} else {
 			logger.Printf("gRPC HMAC auth: DISABLED (set PORTUNUS_HMAC_SECRET to enable)")

--- a/server/cmd/portunus-server/main.go
+++ b/server/cmd/portunus-server/main.go
@@ -24,8 +24,8 @@ import (
 	"github.com/BrandonDHaskell/Portunus/server/internal/db"
 	"github.com/BrandonDHaskell/Portunus/server/internal/grpcapi"
 	"github.com/BrandonDHaskell/Portunus/server/internal/httpapi"
-	"github.com/BrandonDHaskell/Portunus/server/internal/replay"
 	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/service"
+	"github.com/BrandonDHaskell/Portunus/server/internal/replay"
 
 	sqlitestore "github.com/BrandonDHaskell/Portunus/server/internal/portunus/store/sqlite"
 )

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -73,6 +73,11 @@ type Config struct {
 	// CredentialHashSecret keys the HMAC-SHA256 credential-ID hashing.
 	// Generate with: openssl rand -hex 32. Required in prod.
 	CredentialHashSecret string
+
+	// AllowUnkeyedCredentialHash permits starting without a CredentialHashSecret
+	// (resulting in reversible SHA-256 hashes).  Dev/test escape hatch only —
+	// never set in production.  Set PORTUNUS_ALLOW_UNKEYED_CREDENTIAL_HASH=true.
+	AllowUnkeyedCredentialHash bool
 }
 
 // Validate enforces per-profile invariants.
@@ -137,6 +142,8 @@ func FromEnv() (Config, error) {
 		TLSKeyFile:           strings.TrimSpace(os.Getenv("PORTUNUS_TLS_KEY_FILE")),
 		HMACSecret:           os.Getenv("PORTUNUS_HMAC_SECRET"),
 		CredentialHashSecret: os.Getenv("PORTUNUS_CREDENTIAL_HASH_SECRET"),
+		AllowUnkeyedCredentialHash: strings.EqualFold(os.Getenv("PORTUNUS_ALLOW_UNKEYED_CREDENTIAL_HASH"), "true") ||
+			os.Getenv("PORTUNUS_ALLOW_UNKEYED_CREDENTIAL_HASH") == "1",
 	}, nil
 }
 

--- a/server/internal/db/open.go
+++ b/server/internal/db/open.go
@@ -18,8 +18,10 @@ func Open(ctx context.Context, cfg Config) (*sql.DB, error) {
 		cfg.Path = "./data/portunus.db"
 	}
 
-	// Ensure DB parent directory exists.
-	if err := os.MkdirAll(filepath.Dir(cfg.Path), 0o755); err != nil {
+	// Ensure DB parent directory exists with restrictive permissions so the
+	// credential store, session tokens, and bcrypt hashes are not world-readable
+	// (F-8).  0o700: only the service user can enter or list the directory.
+	if err := os.MkdirAll(filepath.Dir(cfg.Path), 0o700); err != nil {
 		return nil, fmt.Errorf("mkdir db dir: %w", err)
 	}
 
@@ -58,5 +60,16 @@ func Open(ctx context.Context, cfg Config) (*sql.DB, error) {
 		return nil, err
 	}
 
+	// Tighten file permissions after open so the DB file and its WAL/SHM
+	// companions are readable only by the service user (F-8).
+	// Best-effort: WAL and SHM may not exist yet for a fresh DB.
+	chmodIfExists(cfg.Path, 0o600)
+	chmodIfExists(cfg.Path+"-wal", 0o600)
+	chmodIfExists(cfg.Path+"-shm", 0o600)
+
 	return db, nil
+}
+
+func chmodIfExists(path string, mode os.FileMode) {
+	_ = os.Chmod(path, mode)
 }

--- a/server/internal/grpcapi/interceptors.go
+++ b/server/internal/grpcapi/interceptors.go
@@ -5,12 +5,13 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log"
-	"sync"
 	"time"
 
 	pb "github.com/BrandonDHaskell/Portunus/server/api/portunus/v1"
+	"github.com/BrandonDHaskell/Portunus/server/internal/replay"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -33,9 +34,8 @@ const hmacHeaderKey = "x-portunus-sig"
 //
 // The access projection includes the nonce (hex-encoded) and requested_at so
 // that every request has a unique signed payload — a captured access request
-// cannot be replayed because the nonce is single-use.  requested_at may be
-// empty when the device clock is not yet synced; the server skips the timestamp
-// window check in that case but still enforces nonce uniqueness.
+// cannot be replayed because the nonce is single-use.  requested_at must be
+// present when HMAC is enabled; the server rejects requests with empty timestamps.
 func hmacProjection(req interface{}) ([]byte, error) {
 	switch m := req.(type) {
 	case *pb.HeartbeatRequest:
@@ -81,78 +81,6 @@ func AccessResponseSig(secret, moduleID, credentialID string, granted bool) stri
 	return hex.EncodeToString(mac.Sum(nil))
 }
 
-// ── Replay protection ─────────────────────────────────────────────────────────
-
-// ReplayStore tracks recently-seen access-request nonces to detect replayed
-// messages.  It pairs with the timestamp window: a request is rejected if its
-// nonce was seen within the window, or if its timestamp is older than the window.
-//
-// The store is safe for concurrent use.  Expired entries are purged lazily on
-// each Check call so memory stays bounded to (window / fastest scan rate) entries.
-type ReplayStore struct {
-	mu      sync.Mutex
-	window  time.Duration
-	entries map[string]time.Time // key: moduleID+":"+nonceHex, value: expiry
-}
-
-// NewReplayStore creates a ReplayStore with the given sliding window duration.
-// A window of 60 seconds is appropriate for most door deployments: it exceeds
-// any reasonable network round-trip while being short enough that the nonce map
-// stays tiny even under sustained load.
-func NewReplayStore(window time.Duration) *ReplayStore {
-	return &ReplayStore{
-		window:  window,
-		entries: make(map[string]time.Time),
-	}
-}
-
-// Check validates that a nonce has not been seen before within the window, and
-// optionally that the timestamp is fresh.  On success it records the nonce so
-// subsequent calls with the same nonce are rejected.
-//
-// moduleID namespaces nonces so different devices cannot collide.
-// nonceHex is the hex-encoded nonce from the request (may be empty for old firmware).
-// requestedAt is the RFC 3339 device timestamp (empty when clock not synced).
-//
-// Returns a non-nil error (with a gRPC status code embedded) on rejection.
-func (r *ReplayStore) Check(moduleID, nonceHex, requestedAt string) error {
-	now := time.Now().UTC()
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	// Purge expired entries to keep the map bounded.
-	for k, expiry := range r.entries {
-		if now.After(expiry) {
-			delete(r.entries, k)
-		}
-	}
-
-	// Timestamp window check — only when the device provides a timestamp.
-	if requestedAt != "" {
-		ts, err := time.Parse(time.RFC3339Nano, requestedAt)
-		if err != nil {
-			return status.Errorf(codes.InvalidArgument, "replay: unparseable requested_at")
-		}
-		age := now.Sub(ts.UTC())
-		if age > r.window || age < -r.window {
-			return status.Errorf(codes.Unauthenticated, "replay: request timestamp out of window")
-		}
-	}
-
-	// Nonce uniqueness check — skip only when nonce is completely absent
-	// (e.g. old firmware that predates this field).
-	if nonceHex != "" {
-		key := moduleID + ":" + nonceHex
-		if _, seen := r.entries[key]; seen {
-			return status.Errorf(codes.Unauthenticated, "replay: nonce already seen")
-		}
-		r.entries[key] = now.Add(r.window)
-	}
-
-	return nil
-}
-
 // HMACInterceptor returns a gRPC unary server interceptor that verifies
 // the HMAC-SHA256 signature attached as custom metadata by the ESP32, then
 // — for AccessRequests — checks the request against store to reject replays.
@@ -164,8 +92,8 @@ func (r *ReplayStore) Check(moduleID, nonceHex, requestedAt string) error {
 // the projection — both use the same pre-shared secret.
 //
 // When secret is empty, the interceptor is a no-op pass-through.
-// store may be nil to disable replay protection (not recommended for production).
-func HMACInterceptor(secret string, store *ReplayStore) grpc.UnaryServerInterceptor {
+// replayStore may be nil to disable replay protection (not recommended for production).
+func HMACInterceptor(secret string, replayStore *replay.Store) grpc.UnaryServerInterceptor {
 	if secret == "" {
 		// No secret configured — pass everything through.
 		return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
@@ -210,15 +138,32 @@ func HMACInterceptor(secret string, store *ReplayStore) grpc.UnaryServerIntercep
 		}
 
 		// Replay protection — only for access requests, only when a store is wired.
-		if store != nil {
+		if replayStore != nil {
 			if ar, ok := req.(*pb.AccessRequest); ok {
-				if err := store.Check(ar.ModuleId, hex.EncodeToString(ar.Nonce), ar.RequestedAt); err != nil {
-					return nil, err
+				nonceHex := hex.EncodeToString(ar.Nonce)
+				if err := replayStore.Check(ar.ModuleId, nonceHex, ar.RequestedAt); err != nil {
+					return nil, replayErrToStatus(err)
 				}
 			}
 		}
 
 		return handler(ctx, req)
+	}
+}
+
+// replayErrToStatus converts a replay sentinel error into a gRPC status error.
+func replayErrToStatus(err error) error {
+	switch {
+	case errors.Is(err, replay.ErrNonceSeen):
+		return status.Errorf(codes.Unauthenticated, "replay: nonce already seen")
+	case errors.Is(err, replay.ErrTimestampWindow):
+		return status.Errorf(codes.Unauthenticated, "replay: request timestamp out of window")
+	case errors.Is(err, replay.ErrTimestampRequired):
+		return status.Errorf(codes.Unauthenticated, "replay: requested_at is required")
+	case errors.Is(err, replay.ErrTimestampInvalid):
+		return status.Errorf(codes.InvalidArgument, "replay: invalid requested_at timestamp")
+	default:
+		return status.Errorf(codes.Unauthenticated, "replay: %v", err)
 	}
 }
 

--- a/server/internal/grpcapi/interceptors_test.go
+++ b/server/internal/grpcapi/interceptors_test.go
@@ -11,6 +11,7 @@ import (
 
 	pb "github.com/BrandonDHaskell/Portunus/server/api/portunus/v1"
 	"github.com/BrandonDHaskell/Portunus/server/internal/grpcapi"
+	"github.com/BrandonDHaskell/Portunus/server/internal/replay"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -104,7 +105,7 @@ func TestHMACInterceptor_ValidHeartbeat_Passes(t *testing.T) {
 }
 
 func TestHMACInterceptor_ValidAccessRequest_Passes(t *testing.T) {
-	store := grpcapi.NewReplayStore(60 * time.Second)
+	store := replay.NewStore(60 * time.Second)
 	interceptor := grpcapi.HMACInterceptor(testHMACSecret, store)
 	req := freshAccessRequest("door-001", "AABBCCDD")
 
@@ -173,7 +174,7 @@ func TestHMACInterceptor_BadHexSignature_Unauthenticated(t *testing.T) {
 // ── replay protection ─────────────────────────────────────────────────────────
 
 func TestHMACInterceptor_ReplayedNonce_Unauthenticated(t *testing.T) {
-	store := grpcapi.NewReplayStore(60 * time.Second)
+	store := replay.NewStore(60 * time.Second)
 	interceptor := grpcapi.HMACInterceptor(testHMACSecret, store)
 	req := freshAccessRequest("door-001", "AABBCCDD")
 
@@ -191,7 +192,7 @@ func TestHMACInterceptor_ReplayedNonce_Unauthenticated(t *testing.T) {
 }
 
 func TestHMACInterceptor_FreshNonce_Accepted(t *testing.T) {
-	store := grpcapi.NewReplayStore(60 * time.Second)
+	store := replay.NewStore(60 * time.Second)
 	interceptor := grpcapi.HMACInterceptor(testHMACSecret, store)
 
 	// Two requests with different nonces from the same module should both pass.
@@ -216,7 +217,7 @@ func TestHMACInterceptor_FreshNonce_Accepted(t *testing.T) {
 }
 
 func TestHMACInterceptor_StaleTimestamp_Unauthenticated(t *testing.T) {
-	store := grpcapi.NewReplayStore(60 * time.Second)
+	store := replay.NewStore(60 * time.Second)
 	interceptor := grpcapi.HMACInterceptor(testHMACSecret, store)
 
 	req := freshAccessRequest("door-001", "AABBCCDD")
@@ -230,10 +231,10 @@ func TestHMACInterceptor_StaleTimestamp_Unauthenticated(t *testing.T) {
 	assertCode(t, err, codes.Unauthenticated)
 }
 
-func TestHMACInterceptor_EmptyTimestamp_Accepted(t *testing.T) {
-	// Empty requested_at means the device clock is not yet synced.
-	// The server skips the timestamp check but still enforces nonce uniqueness.
-	store := grpcapi.NewReplayStore(60 * time.Second)
+func TestHMACInterceptor_EmptyTimestamp_Rejected(t *testing.T) {
+	// When HMAC is enabled, a missing requested_at is always rejected (F-5).
+	// Firmware must provide a synchronised clock timestamp.
+	store := replay.NewStore(60 * time.Second)
 	interceptor := grpcapi.HMACInterceptor(testHMACSecret, store)
 
 	req := freshAccessRequest("door-001", "AABBCCDD")
@@ -242,9 +243,8 @@ func TestHMACInterceptor_EmptyTimestamp_Accepted(t *testing.T) {
 	ctx := metadata.NewIncomingContext(context.Background(),
 		metadata.Pairs(hmacSigHeader, sign(req, testHMACSecret)))
 
-	if _, err := invoke(interceptor, ctx, req); err != nil {
-		t.Fatalf("empty requested_at should be accepted, got: %v", err)
-	}
+	_, err := invoke(interceptor, ctx, req)
+	assertCode(t, err, codes.Unauthenticated)
 }
 
 func TestHMACInterceptor_NoStore_NoReplayCheck(t *testing.T) {

--- a/server/internal/httpapi/auth.go
+++ b/server/internal/httpapi/auth.go
@@ -25,9 +25,15 @@ func (s *Server) handleAdminLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !s.loginLimiter.Allow(body.Username, r.RemoteAddr) {
+		writeError(w, http.StatusTooManyRequests, "too_many_attempts", "too many failed login attempts, try again later")
+		return
+	}
+
 	sessionID, err := s.authService.Login(r.Context(), body.Username, body.Password)
 	if err != nil {
 		if errors.Is(err, service.ErrInvalidCredentials) || errors.Is(err, service.ErrAccountDisabled) {
+			s.loginLimiter.RecordFailure(body.Username, r.RemoteAddr)
 			writeError(w, http.StatusUnauthorized, "invalid_credentials", "invalid username or password")
 			return
 		}
@@ -36,6 +42,7 @@ func (s *Server) handleAdminLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.loginLimiter.Reset(body.Username, r.RemoteAddr)
 	setSessionCookie(w, sessionID, s.tlsEnabled)
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }

--- a/server/internal/httpapi/login_limiter.go
+++ b/server/internal/httpapi/login_limiter.go
@@ -1,0 +1,92 @@
+package httpapi
+
+import (
+	"net"
+	"sync"
+	"time"
+)
+
+// loginLimiter enforces a sliding-window failed-attempt limit on login routes.
+// It is keyed on "username::clientIP" so each (user, source) pair has its own
+// independent counter.  The store is bounded: entries older than the window are
+// purged lazily on each call.
+//
+// Safe for concurrent use.
+type loginLimiter struct {
+	mu        sync.Mutex
+	window    time.Duration
+	threshold int
+	entries   map[string][]time.Time // key → slice of recent failure timestamps
+}
+
+func newLoginLimiter(window time.Duration, threshold int) *loginLimiter {
+	return &loginLimiter{
+		window:    window,
+		threshold: threshold,
+		entries:   make(map[string][]time.Time),
+	}
+}
+
+// key returns the rate-limit key for a username + remote address pair.
+// It strips the port from remoteAddr so IPv4 and IPv6 both work.
+func loginKey(username, remoteAddr string) string {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		host = remoteAddr // fall back to raw string if no port
+	}
+	return username + "::" + host
+}
+
+// Allow returns true if the caller is under the failure threshold.
+// It does NOT record a new attempt; call RecordFailure after a confirmed
+// authentication failure and Reset after a success.
+func (l *loginLimiter) Allow(username, remoteAddr string) bool {
+	now := time.Now().UTC()
+	key := loginKey(username, remoteAddr)
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.purge(key, now)
+	return len(l.entries[key]) < l.threshold
+}
+
+// RecordFailure records a failed attempt for the given username + IP.
+func (l *loginLimiter) RecordFailure(username, remoteAddr string) {
+	now := time.Now().UTC()
+	key := loginKey(username, remoteAddr)
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.purge(key, now)
+	l.entries[key] = append(l.entries[key], now)
+}
+
+// Reset clears the failure record for the given username + IP after a
+// successful login.
+func (l *loginLimiter) Reset(username, remoteAddr string) {
+	key := loginKey(username, remoteAddr)
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	delete(l.entries, key)
+}
+
+// purge removes timestamps older than the window from a single entry.
+// Must be called with l.mu held.
+func (l *loginLimiter) purge(key string, now time.Time) {
+	times := l.entries[key]
+	cutoff := now.Add(-l.window)
+	i := 0
+	for i < len(times) && times[i].Before(cutoff) {
+		i++
+	}
+	if i > 0 {
+		l.entries[key] = times[i:]
+	}
+	if len(l.entries[key]) == 0 {
+		delete(l.entries, key)
+	}
+}

--- a/server/internal/httpapi/server.go
+++ b/server/internal/httpapi/server.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	pb "github.com/BrandonDHaskell/Portunus/server/api/portunus/v1"
+	"github.com/BrandonDHaskell/Portunus/server/internal/replay"
 	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/permissions"
 	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/service"
 	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/store"
@@ -36,6 +37,10 @@ type Dependencies struct {
 	// HMACSecret is the pre-shared key for X-Portunus-Sig verification.
 	// Leave empty to disable HMAC enforcement (not recommended for production).
 	HMACSecret string
+	// ReplayStore is the shared nonce+timestamp replay-protection store.
+	// Must be the same instance used by the gRPC server so nonces are
+	// deduplicated across both transports.  Required when HMACSecret is set.
+	ReplayStore *replay.Store
 	// CredentialHashSecret is the HMAC key used to hash credential UIDs before storage.
 	// Must match the key used by AccessService.  Leave nil only in dev/test.
 	CredentialHashSecret []byte
@@ -59,6 +64,8 @@ type Server struct {
 	auditStore           store.AuditStore
 	credentialHashSecret []byte
 	hmacSecret           string
+	replayStore          *replay.Store
+	loginLimiter         *loginLimiter
 	tlsEnabled           bool
 }
 
@@ -80,7 +87,10 @@ func NewServer(d Dependencies) *Server {
 		auditStore:           d.AuditStore,
 		credentialHashSecret: d.CredentialHashSecret,
 		hmacSecret:           d.HMACSecret,
-		tlsEnabled:           d.TLSEnabled,
+		replayStore:          d.ReplayStore,
+		// 5 failures per username+IP within 60 seconds triggers a 429.
+		loginLimiter: newLoginLimiter(60*time.Second, 5),
+		tlsEnabled:   d.TLSEnabled,
 	}
 
 	// ── Device endpoints (ESP32 modules) ────────────────────────────────
@@ -324,6 +334,21 @@ func (s *Server) handleAccessRequest(w http.ResponseWriter, r *http.Request) {
 		if err := dec.Decode(&req); err != nil {
 			writeError(w, http.StatusBadRequest, "bad_json", "invalid JSON body")
 			return
+		}
+	}
+
+	// When HMAC is enabled: require a nonce and validate replay (F-3, D3).
+	if s.hmacSecret != "" {
+		if len(req.Nonce) == 0 {
+			writeError(w, http.StatusUnauthorized, "missing_nonce", "nonce is required for access requests")
+			return
+		}
+		if s.replayStore != nil {
+			nonceHex := hex.EncodeToString(req.Nonce)
+			if err := s.replayStore.Check(req.ModuleID, nonceHex, req.RequestedAt); err != nil {
+				writeError(w, http.StatusUnauthorized, "replay", err.Error())
+				return
+			}
 		}
 	}
 

--- a/server/internal/httpapi/server.go
+++ b/server/internal/httpapi/server.go
@@ -14,11 +14,11 @@ import (
 	"time"
 
 	pb "github.com/BrandonDHaskell/Portunus/server/api/portunus/v1"
-	"github.com/BrandonDHaskell/Portunus/server/internal/replay"
 	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/permissions"
 	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/service"
 	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/store"
 	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/types"
+	"github.com/BrandonDHaskell/Portunus/server/internal/replay"
 )
 
 type Dependencies struct {

--- a/server/internal/httpapi/ui_auth.go
+++ b/server/internal/httpapi/ui_auth.go
@@ -44,9 +44,17 @@ func (s *Server) handleUILogin(w http.ResponseWriter, r *http.Request) {
 	password := r.FormValue("password")
 	d.Form["username"] = username
 
+	if !s.loginLimiter.Allow(username, r.RemoteAddr) {
+		d.Flash = "Too many failed login attempts. Please try again later."
+		d.FlashType = "error"
+		render.render(w, "login", d)
+		return
+	}
+
 	sessionID, err := s.authService.Login(r.Context(), username, password)
 	if err != nil {
 		if errors.Is(err, service.ErrInvalidCredentials) || errors.Is(err, service.ErrAccountDisabled) {
+			s.loginLimiter.RecordFailure(username, r.RemoteAddr)
 			d.Flash = "Invalid username or password."
 			d.FlashType = "error"
 			render.render(w, "login", d)
@@ -59,6 +67,7 @@ func (s *Server) handleUILogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.loginLimiter.Reset(username, r.RemoteAddr)
 	setSessionCookie(w, sessionID, s.tlsEnabled)
 	http.Redirect(w, r, "/admin/ui/", http.StatusSeeOther)
 }

--- a/server/internal/httpapi/ui_roles.go
+++ b/server/internal/httpapi/ui_roles.go
@@ -137,9 +137,19 @@ func (s *Server) handleUIRolesSetPermissions(w http.ResponseWriter, r *http.Requ
 		}
 	}
 
-	if err := s.roleService.SetPermissions(r.Context(), roleID, valid); err != nil {
+	sess := sessionFromContext(r.Context())
+	if sess == nil {
+		flashRedirect(w, r, "/admin/ui/roles/"+roleID, "Session expired.", "error")
+		return
+	}
+
+	if err := s.roleService.SetPermissions(r.Context(), sess.Permissions, roleID, valid); err != nil {
 		if errors.Is(err, service.ErrAdminRoleImmutable) {
 			flashRedirect(w, r, "/admin/ui/roles/"+roleID, "The admin role's permissions cannot be modified.", "error")
+			return
+		}
+		if errors.Is(err, service.ErrPermissionSubsetViolation) {
+			flashRedirect(w, r, "/admin/ui/roles/"+roleID, "You cannot grant a permission you do not hold.", "error")
 			return
 		}
 		s.logger.Printf("ui set permissions: %v", err)

--- a/server/internal/httpapi/ui_users.go
+++ b/server/internal/httpapi/ui_users.go
@@ -203,13 +203,21 @@ func (s *Server) handleUIUsersAssignRole(w http.ResponseWriter, r *http.Request)
 
 	roleID := r.FormValue("role_id")
 	sess := sessionFromContext(r.Context())
-	if err := s.adminUserService.AssignRole(r.Context(), sess.AdminUUID, uuid, roleID); err != nil {
+	if sess == nil {
+		flashRedirect(w, r, "/admin/ui/users/"+uuid, "Session expired.", "error")
+		return
+	}
+	if err := s.adminUserService.AssignRole(r.Context(), sess.AdminUUID, sess.Permissions, uuid, roleID); err != nil {
 		if errors.Is(err, service.ErrAdminUserNotFound) {
 			http.NotFound(w, r)
 			return
 		}
 		if errors.Is(err, service.ErrLastAdmin) {
 			flashRedirect(w, r, "/admin/ui/users/"+uuid, "Cannot move the last admin user off the admin role.", "error")
+			return
+		}
+		if errors.Is(err, service.ErrPermissionSubsetViolation) {
+			flashRedirect(w, r, "/admin/ui/users/"+uuid, "You cannot assign a role with permissions you do not hold.", "error")
 			return
 		}
 		s.logger.Printf("ui assign role: %v", err)

--- a/server/internal/portunus/service/admin_user_service.go
+++ b/server/internal/portunus/service/admin_user_service.go
@@ -13,9 +13,9 @@ import (
 )
 
 var (
-	ErrAdminUserNotFound        = errors.New("admin user not found")
-	ErrCannotSelfDisable        = errors.New("cannot disable your own account")
-	ErrLastAdmin                = errors.New("at least one enabled admin user must retain the admin role")
+	ErrAdminUserNotFound         = errors.New("admin user not found")
+	ErrCannotSelfDisable         = errors.New("cannot disable your own account")
+	ErrLastAdmin                 = errors.New("at least one enabled admin user must retain the admin role")
 	ErrPermissionSubsetViolation = errors.New("cannot grant a permission you do not hold")
 )
 

--- a/server/internal/portunus/service/admin_user_service.go
+++ b/server/internal/portunus/service/admin_user_service.go
@@ -13,9 +13,10 @@ import (
 )
 
 var (
-	ErrAdminUserNotFound = errors.New("admin user not found")
-	ErrCannotSelfDisable = errors.New("cannot disable your own account")
-	ErrLastAdmin         = errors.New("at least one enabled admin user must retain the admin role")
+	ErrAdminUserNotFound        = errors.New("admin user not found")
+	ErrCannotSelfDisable        = errors.New("cannot disable your own account")
+	ErrLastAdmin                = errors.New("at least one enabled admin user must retain the admin role")
+	ErrPermissionSubsetViolation = errors.New("cannot grant a permission you do not hold")
 )
 
 // AdminUserInfo is the view type for admin user management pages.
@@ -54,6 +55,9 @@ func (s *AdminUserService) CreateUser(ctx context.Context, callerUUID, username,
 	}
 	if len(password) < 12 {
 		return nil, fmt.Errorf("%w: password must be at least 12 characters", ErrPasswordChangeFailed)
+	}
+	if len(password) > bcryptMaxLen {
+		return nil, fmt.Errorf("%w: password must not exceed %d characters", ErrPasswordChangeFailed, bcryptMaxLen)
 	}
 	roleID = strings.TrimSpace(roleID)
 	if roleID == "" {
@@ -158,7 +162,9 @@ func (s *AdminUserService) SetEnabled(ctx context.Context, uuid, callerUUID stri
 }
 
 // AssignRole assigns a role to an admin user.
-func (s *AdminUserService) AssignRole(ctx context.Context, callerUUID, uuid, roleID string) error {
+// callerPerms is the resolved permission set of the caller; the target role's
+// permissions must be a subset of callerPerms (F-7: no privilege escalation).
+func (s *AdminUserService) AssignRole(ctx context.Context, callerUUID string, callerPerms map[string]struct{}, uuid, roleID string) error {
 	roleID = strings.TrimSpace(roleID)
 	if roleID == "" {
 		return fmt.Errorf("role_id is required")
@@ -168,6 +174,18 @@ func (s *AdminUserService) AssignRole(ctx context.Context, callerUUID, uuid, rol
 			return fmt.Errorf("role %q not found", roleID)
 		}
 		return fmt.Errorf("assign role: verify role: %w", err)
+	}
+
+	// Enforce that the caller can only assign roles whose permission set is a
+	// subset of their own — prevents privilege escalation via role assignment.
+	targetPerms, err := s.roles.GetRolePermissions(ctx, roleID)
+	if err != nil {
+		return fmt.Errorf("assign role: load target permissions: %w", err)
+	}
+	for _, p := range targetPerms {
+		if _, ok := callerPerms[p]; !ok {
+			return ErrPermissionSubsetViolation
+		}
 	}
 
 	if roleID != adminRoleID {

--- a/server/internal/portunus/service/admin_user_service_test.go
+++ b/server/internal/portunus/service/admin_user_service_test.go
@@ -131,7 +131,7 @@ func TestAdminUserService_AssignRole_LastAdminRoleMoveBlocked(t *testing.T) {
 	ctx := context.Background()
 	seedAdminUser(t, us, "uuid-only", "admin", true)
 
-	err := svc.AssignRole(ctx, "uuid-caller", "uuid-only", "operator")
+	err := svc.AssignRole(ctx, "uuid-caller", allPerms(), "uuid-only", "operator")
 	if !errors.Is(err, service.ErrLastAdmin) {
 		t.Fatalf("expected ErrLastAdmin, got: %v", err)
 	}
@@ -144,7 +144,7 @@ func TestAdminUserService_AssignRole_NonLastAdminRoleMoveAllowed(t *testing.T) {
 	seedAdminUser(t, us, "uuid-b", "admin", true)
 
 	// Moving uuid-a to operator is fine because uuid-b still holds admin.
-	if err := svc.AssignRole(ctx, "uuid-b", "uuid-a", "operator"); err != nil {
+	if err := svc.AssignRole(ctx, "uuid-b", allPerms(), "uuid-a", "operator"); err != nil {
 		t.Fatalf("unexpected error moving non-last admin to operator: %v", err)
 	}
 }
@@ -156,7 +156,7 @@ func TestAdminUserService_AssignRole_ToAdminAlwaysAllowed(t *testing.T) {
 	seedAdminUser(t, us, "uuid-op", "operator", true)
 
 	// Elevating an operator to admin should never be blocked by the last-admin guard.
-	if err := svc.AssignRole(ctx, "uuid-admin", "uuid-op", "admin"); err != nil {
+	if err := svc.AssignRole(ctx, "uuid-admin", allPerms(), "uuid-op", "admin"); err != nil {
 		t.Fatalf("unexpected error promoting operator to admin: %v", err)
 	}
 }
@@ -167,7 +167,7 @@ func TestAdminUserService_AssignRole_AuditRoleAssigned(t *testing.T) {
 	seedAdminUser(t, us, "uuid-a", "admin", true)
 	seedAdminUser(t, us, "uuid-b", "admin", true)
 
-	if err := svc.AssignRole(ctx, "uuid-b", "uuid-a", "operator"); err != nil {
+	if err := svc.AssignRole(ctx, "uuid-b", allPerms(), "uuid-a", "operator"); err != nil {
 		t.Fatalf("AssignRole: %v", err)
 	}
 	requireAuditEntry(t, as, "admin_user.role_assigned", "uuid-a")

--- a/server/internal/portunus/service/auth_service.go
+++ b/server/internal/portunus/service/auth_service.go
@@ -65,11 +65,11 @@ func (s *AdminSession) HasPermission(p string) bool {
 // AuthService handles admin authentication: bootstrap, login, logout, session
 // resolution, and password changes.
 type AuthService struct {
-	users              store.AdminUserStore
-	sessions           store.SessionStore
-	roles              store.RoleStore
-	logger             *log.Logger
-	bootstrapPWFile    string // path to write the initial admin password; empty → log it
+	users           store.AdminUserStore
+	sessions        store.SessionStore
+	roles           store.RoleStore
+	logger          *log.Logger
+	bootstrapPWFile string // path to write the initial admin password; empty → log it
 }
 
 func NewAuthService(

--- a/server/internal/portunus/service/auth_service.go
+++ b/server/internal/portunus/service/auth_service.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
+	"sync"
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
@@ -17,7 +19,25 @@ import (
 const (
 	sessionDuration = 8 * time.Hour
 	bcryptCost      = 12
+	bcryptMaxLen    = 72
 )
+
+// dummyHash is a bcrypt hash of a fixed string computed once at first use.
+// It is compared against the supplied password on the "user not found" path so
+// that both paths spend the same bcrypt work before returning ErrInvalidCredentials,
+// preventing username-enumeration via response timing (F-2).
+var (
+	dummyHashOnce sync.Once
+	dummyHash     []byte
+)
+
+func getDummyHash() []byte {
+	dummyHashOnce.Do(func() {
+		h, _ := bcrypt.GenerateFromPassword([]byte("portunus-timing-dummy-constant"), bcryptCost)
+		dummyHash = h
+	})
+	return dummyHash
+}
 
 var (
 	ErrInvalidCredentials   = errors.New("invalid username or password")
@@ -45,10 +65,11 @@ func (s *AdminSession) HasPermission(p string) bool {
 // AuthService handles admin authentication: bootstrap, login, logout, session
 // resolution, and password changes.
 type AuthService struct {
-	users    store.AdminUserStore
-	sessions store.SessionStore
-	roles    store.RoleStore
-	logger   *log.Logger
+	users              store.AdminUserStore
+	sessions           store.SessionStore
+	roles              store.RoleStore
+	logger             *log.Logger
+	bootstrapPWFile    string // path to write the initial admin password; empty → log it
 }
 
 func NewAuthService(
@@ -58,6 +79,14 @@ func NewAuthService(
 	logger *log.Logger,
 ) *AuthService {
 	return &AuthService{users: users, sessions: sessions, roles: roles, logger: logger}
+}
+
+// SetBootstrapPasswordFile configures the path where the initial admin password
+// is written on first boot instead of to the log stream (F-9).  The file is
+// created with mode 0600 so only the service user can read it.
+// Call before Bootstrap.  An empty path reverts to logging (test/dev use only).
+func (s *AuthService) SetBootstrapPasswordFile(path string) {
+	s.bootstrapPWFile = path
 }
 
 // Bootstrap checks whether any admin user exists. If none does, it creates the
@@ -91,12 +120,33 @@ func (s *AuthService) Bootstrap(ctx context.Context) error {
 		return fmt.Errorf("bootstrap: create admin user: %w", err)
 	}
 
-	s.logger.Printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-	s.logger.Printf("FIRST RUN — initial admin account created")
-	s.logger.Printf("  username: admin")
-	s.logger.Printf("  password: %s", password)
-	s.logger.Printf("  You will be required to change this password on first login.")
-	s.logger.Printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	if s.bootstrapPWFile != "" {
+		content := fmt.Sprintf("username: admin\npassword: %s\n", password)
+		if err := os.WriteFile(s.bootstrapPWFile, []byte(content), 0o600); err != nil {
+			// Fall back to logging if we can't write the file.
+			s.logger.Printf("WARNING: could not write bootstrap password file %q: %v — printing to log instead", s.bootstrapPWFile, err)
+			s.logger.Printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+			s.logger.Printf("FIRST RUN — initial admin account created")
+			s.logger.Printf("  username: admin")
+			s.logger.Printf("  password: %s", password)
+			s.logger.Printf("  You will be required to change this password on first login.")
+			s.logger.Printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		} else {
+			s.logger.Printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+			s.logger.Printf("FIRST RUN — initial admin account created")
+			s.logger.Printf("  username: admin")
+			s.logger.Printf("  password written to: %s  (delete after first login)", s.bootstrapPWFile)
+			s.logger.Printf("  You will be required to change this password on first login.")
+			s.logger.Printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		}
+	} else {
+		s.logger.Printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		s.logger.Printf("FIRST RUN — initial admin account created")
+		s.logger.Printf("  username: admin")
+		s.logger.Printf("  password: %s", password)
+		s.logger.Printf("  You will be required to change this password on first login.")
+		s.logger.Printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	}
 
 	return nil
 }
@@ -106,6 +156,10 @@ func (s *AuthService) Login(ctx context.Context, username, password string) (str
 	user, err := s.users.GetAdminUserByUsername(ctx, username)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
+			// Run a dummy bcrypt compare so that a missing username takes the
+			// same wall-clock time as a present-but-wrong-password attempt,
+			// preventing username enumeration via response timing (F-2).
+			_ = bcrypt.CompareHashAndPassword(getDummyHash(), []byte(password))
 			return "", ErrInvalidCredentials
 		}
 		return "", fmt.Errorf("login: %w", err)
@@ -215,6 +269,9 @@ func (s *AuthService) ChangePassword(ctx context.Context, adminUUID, currentPass
 
 	if len(newPassword) < 12 {
 		return fmt.Errorf("%w: password must be at least 12 characters", ErrPasswordChangeFailed)
+	}
+	if len(newPassword) > bcryptMaxLen {
+		return fmt.Errorf("%w: password must not exceed %d characters", ErrPasswordChangeFailed, bcryptMaxLen)
 	}
 
 	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcryptCost)

--- a/server/internal/portunus/service/role_service.go
+++ b/server/internal/portunus/service/role_service.go
@@ -126,9 +126,16 @@ func (s *RoleService) DeleteRole(ctx context.Context, roleID string) error {
 }
 
 // SetPermissions replaces the full permission set for a role.
-func (s *RoleService) SetPermissions(ctx context.Context, roleID string, permissions []string) error {
+// callerPerms is the resolved permission set of the caller; every permission
+// being written must be present in callerPerms (F-7: no privilege escalation).
+func (s *RoleService) SetPermissions(ctx context.Context, callerPerms map[string]struct{}, roleID string, permissions []string) error {
 	if roleID == adminRoleID {
 		return ErrAdminRoleImmutable
+	}
+	for _, p := range permissions {
+		if _, ok := callerPerms[p]; !ok {
+			return ErrPermissionSubsetViolation
+		}
 	}
 	if err := s.roles.SetRolePermissions(ctx, roleID, permissions); err != nil {
 		return fmt.Errorf("set permissions: %w", err)

--- a/server/internal/portunus/service/role_service_test.go
+++ b/server/internal/portunus/service/role_service_test.go
@@ -5,9 +5,20 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/permissions"
 	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/service"
 	sqlitestore "github.com/BrandonDHaskell/Portunus/server/internal/portunus/store/sqlite"
 )
+
+// allPerms returns a permission set containing every known permission,
+// representing a superuser caller for tests that aren't exercising the subset guard.
+func allPerms() map[string]struct{} {
+	m := make(map[string]struct{})
+	for _, p := range permissions.All() {
+		m[p] = struct{}{}
+	}
+	return m
+}
 
 func TestRoleService_SetPermissions_AdminRoleImmutable(t *testing.T) {
 	dbConn, writer := openSvcTestDB(t)
@@ -15,7 +26,7 @@ func TestRoleService_SetPermissions_AdminRoleImmutable(t *testing.T) {
 	svc := service.NewRoleService(rs)
 	ctx := context.Background()
 
-	err := svc.SetPermissions(ctx, "admin", []string{"door.unlock_remote"})
+	err := svc.SetPermissions(ctx, allPerms(), "admin", []string{"door.unlock_remote"})
 	if !errors.Is(err, service.ErrAdminRoleImmutable) {
 		t.Fatalf("expected ErrAdminRoleImmutable, got: %v", err)
 	}
@@ -28,7 +39,7 @@ func TestRoleService_SetPermissions_AdminRoleImmutable_Empty(t *testing.T) {
 	ctx := context.Background()
 
 	// Even clearing the admin role's permissions must be blocked.
-	err := svc.SetPermissions(ctx, "admin", []string{})
+	err := svc.SetPermissions(ctx, allPerms(), "admin", []string{})
 	if !errors.Is(err, service.ErrAdminRoleImmutable) {
 		t.Fatalf("expected ErrAdminRoleImmutable for empty perm list, got: %v", err)
 	}
@@ -40,10 +51,24 @@ func TestRoleService_SetPermissions_OtherRolesEditable(t *testing.T) {
 	svc := service.NewRoleService(rs)
 	ctx := context.Background()
 
-	if err := svc.SetPermissions(ctx, "operator", []string{"door.unlock_remote"}); err != nil {
+	if err := svc.SetPermissions(ctx, allPerms(), "operator", []string{"module.list"}); err != nil {
 		t.Fatalf("unexpected error setting permissions on operator role: %v", err)
 	}
-	if err := svc.SetPermissions(ctx, "viewer", []string{"audit.view"}); err != nil {
+	if err := svc.SetPermissions(ctx, allPerms(), "viewer", []string{"audit_log.list"}); err != nil {
 		t.Fatalf("unexpected error setting permissions on viewer role: %v", err)
+	}
+}
+
+func TestRoleService_SetPermissions_SubsetViolation(t *testing.T) {
+	dbConn, writer := openSvcTestDB(t)
+	rs := sqlitestore.NewRoleStore(dbConn, writer)
+	svc := service.NewRoleService(rs)
+	ctx := context.Background()
+
+	// Caller holds only "audit_log.list"; trying to grant "module.list" must fail.
+	callerPerms := map[string]struct{}{"audit_log.list": {}}
+	err := svc.SetPermissions(ctx, callerPerms, "operator", []string{"module.list"})
+	if !errors.Is(err, service.ErrPermissionSubsetViolation) {
+		t.Fatalf("expected ErrPermissionSubsetViolation, got: %v", err)
 	}
 }

--- a/server/internal/portunus/service/session_sweeper.go
+++ b/server/internal/portunus/service/session_sweeper.go
@@ -1,0 +1,75 @@
+package service
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/BrandonDHaskell/Portunus/server/internal/portunus/store"
+)
+
+// SessionSweeper periodically deletes expired session rows.  It is safe to
+// stop via its context or the Stop method.
+//
+// Expired sessions are already rejected at resolve time; this sweeper only
+// prevents unbounded table growth for sessions that are never resolved again.
+type SessionSweeper struct {
+	store    store.SessionStore
+	interval time.Duration
+	logger   *log.Logger
+	cancel   context.CancelFunc
+	done     chan struct{}
+}
+
+// NewSessionSweeper creates a sweeper that runs on the given interval.
+// If interval ≤ 0, it defaults to 1 hour.
+func NewSessionSweeper(s store.SessionStore, interval time.Duration, logger *log.Logger) *SessionSweeper {
+	if interval <= 0 {
+		interval = time.Hour
+	}
+	return &SessionSweeper{
+		store:    s,
+		interval: interval,
+		logger:   logger,
+		done:     make(chan struct{}),
+	}
+}
+
+// Start begins the background sweep loop.
+func (sw *SessionSweeper) Start(ctx context.Context) {
+	ctx, sw.cancel = context.WithCancel(ctx)
+	go sw.loop(ctx)
+	sw.logger.Printf("session sweeper started (interval=%s)", sw.interval)
+}
+
+// Stop signals the sweeper to exit and waits for it to finish.
+func (sw *SessionSweeper) Stop() {
+	if sw.cancel != nil {
+		sw.cancel()
+	}
+	<-sw.done
+}
+
+func (sw *SessionSweeper) loop(ctx context.Context) {
+	defer close(sw.done)
+
+	sw.sweep(ctx)
+
+	ticker := time.NewTicker(sw.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			sw.sweep(ctx)
+		}
+	}
+}
+
+func (sw *SessionSweeper) sweep(ctx context.Context) {
+	if err := sw.store.DeleteExpiredSessions(ctx); err != nil {
+		sw.logger.Printf("session sweep error: %v", err)
+	}
+}

--- a/server/internal/replay/replay.go
+++ b/server/internal/replay/replay.go
@@ -1,0 +1,90 @@
+// Package replay provides a nonce+timestamp replay-protection store shared by
+// the HTTP and gRPC device transports.  Both transports must share one instance
+// so that a nonce replayed across transports is also rejected.
+package replay
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// Sentinel errors returned by Store.Check.  Callers translate these into their
+// own transport-layer error codes (HTTP 401, gRPC Unauthenticated, etc.).
+var (
+	ErrNonceSeen         = errors.New("replay: nonce already seen")
+	ErrTimestampWindow   = errors.New("replay: request timestamp out of window")
+	ErrTimestampRequired = errors.New("replay: requested_at is required")
+	ErrTimestampInvalid  = errors.New("replay: requested_at is not a valid RFC 3339 timestamp")
+)
+
+// Store tracks recently-seen access-request nonces to reject replayed messages.
+// It pairs nonce uniqueness with a timestamp window: a request is rejected if
+// its nonce was seen within the window OR if its timestamp is outside the window.
+//
+// A missing timestamp is always rejected — when HMAC is enabled, the firmware
+// must provide a synchronised clock timestamp so the window check is binding.
+// (Old firmware that predates the timestamp field must be updated.)
+//
+// Store is safe for concurrent use.  Expired entries are purged lazily on each
+// Check call so memory stays bounded to roughly (window / fastest scan rate).
+type Store struct {
+	mu      sync.Mutex
+	window  time.Duration
+	entries map[string]time.Time // key: moduleID+":"+nonceHex  value: expiry
+}
+
+// NewStore creates a Store with the given sliding-window duration.
+// A window of 60 seconds suits most door deployments.
+func NewStore(window time.Duration) *Store {
+	return &Store{
+		window:  window,
+		entries: make(map[string]time.Time),
+	}
+}
+
+// Check validates that:
+//  1. requestedAt is present and parses as RFC 3339.
+//  2. The timestamp is within ±window of now.
+//  3. nonceHex has not been seen before within the window.
+//
+// On success it records the nonce; subsequent calls with the same
+// moduleID+nonceHex are rejected until the entry expires.
+//
+// moduleID namespaces nonces so different devices cannot collide.
+func (s *Store) Check(moduleID, nonceHex, requestedAt string) error {
+	now := time.Now().UTC()
+
+	if requestedAt == "" {
+		return ErrTimestampRequired
+	}
+
+	ts, err := time.Parse(time.RFC3339Nano, requestedAt)
+	if err != nil {
+		return ErrTimestampInvalid
+	}
+	age := now.Sub(ts.UTC())
+	if age > s.window || age < -s.window {
+		return ErrTimestampWindow
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Purge expired entries to keep the map bounded.
+	for k, expiry := range s.entries {
+		if now.After(expiry) {
+			delete(s.entries, k)
+		}
+	}
+
+	if nonceHex != "" {
+		key := moduleID + ":" + nonceHex
+		if _, seen := s.entries[key]; seen {
+			return ErrNonceSeen
+		}
+		s.entries[key] = now.Add(s.window)
+	}
+
+	return nil
+}


### PR DESCRIPTION
internal/replay/replay.go — shared Store used by both transports; requires timestamp + nonce, rejects replays (F-3, F-5)
service/session_sweeper.go — hourly DeleteExpiredSessions background worker (F-11)
httpapi/login_limiter.go — sliding-window limiter, 5 failures/60s per username::IP (F-1)
Changes by finding:

| Finding	| What changed | 
|--------|--------|
| F-1	| Rate limiter wired into both handleAdminLogin and handleUILogin; returns 429 when exceeded, resets on success| 
| F-2	| auth_service.go: dummy bcrypt via sync.Once on not-found path to equalize response latency| 
| F-3	| interceptors.go + server.go: both transports share one replay.Store; HTTP path hard-rejects empty nonce (D3)| 
| F-5	| replay.Store.Check rejects empty requested_at; gRPC test updated accordingly| 
| F-6	| config.go + main.go: PORTUNUS_ALLOW_UNKEYED_CREDENTIAL_HASH=true required to start without a hash secret; otherwise Fatalf| 
| F-7	| SetPermissions and AssignRole each take callerPerms map[string]struct{}; every permission being written must be in the caller's set| 
| F-8	| db/open.go: directory created 0o700, DB file and WAL/SHM chmoded to 0o600 after open| 
| F-9	| auth_service.go: SetBootstrapPasswordFile setter; Bootstrap writes to a 0o600 file and logs the path, not the secret| 
| F-10	| Both ChangePassword and CreateUser reject passwords longer than 72 bytes| 
| F-11	| Session sweeper started in main.go, sweeps hourly| 